### PR TITLE
fix headers and errors

### DIFF
--- a/bin/tools/DataProcessor.py
+++ b/bin/tools/DataProcessor.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # encoding: utf-8
 """
+Simple DataProcessor.
+
 """
 
 import argparse

--- a/bin/tools/PickleProcessor.py
+++ b/bin/tools/PickleProcessor.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # encoding: utf-8
 """
+PickleProcessor.
+
 """
 
 import cPickle
@@ -10,7 +12,7 @@ from madmom.processors import io_arguments
 
 
 def main():
-    """Generic Pickle Processor."""
+    """PickleProcessor."""
     # define parser
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter, description='''

--- a/madmom/audio/cepstrogram.py
+++ b/madmom/audio/cepstrogram.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains all cepstrogram related functionality.
 
@@ -13,12 +17,15 @@ from .filters import MelFilterbank
 from .spectrogram import Spectrogram
 
 
-class Cepstrogram(PropertyMixin, np.ndarray):
+class Cepstrogram(np.ndarray, PropertyMixin):
     """
     The Cepstrogram class represents a transformed Spectrogram. This generic
     class applies some transformation (usually a DCT) on a spectrogram.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self, spectrogram, transform=dct, **kwargs):
         """
@@ -99,6 +106,8 @@ class CepstrogramProcessor(Processor):
         :param transform: transform
 
         """
+        # pylint: disable=unused-argument
+
         self.transform = transform
 
     def process(self, data):
@@ -137,6 +146,9 @@ class MFCC(Cepstrogram):
     5) The MFCCs are the amplitudes of the resulting spectrum
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self, spectrogram, transform=dct, filterbank=MelFilterbank,
                  num_bands=MFCC_BANDS, fmin=MFCC_FMIN, fmax=MFCC_FMAX,
@@ -294,6 +306,8 @@ class MFCCProcessor(Processor):
         :param transform:    transformation to be applied on the spectrogram
 
         """
+        # pylint: disable=unused-argument
+
         self.num_bands = num_bands
         self.fmin = fmin
         self.fmax = fmax

--- a/madmom/audio/chroma.py
+++ b/madmom/audio/chroma.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains chroma related functionality.
 
@@ -43,6 +47,9 @@ class PitchClassProfile(FilteredSpectrogram):
     Beijing, China
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self, spectrogram, filterbank=PCP, num_classes=PCP.CLASSES,
                  fmin=PCP.FMIN, fmax=PCP.FMAX, fref=A4, **kwargs):
@@ -109,6 +116,9 @@ class HarmonicPitchClassProfile(PitchClassProfile):
     PhD thesis, Universitat Pompeu Fabra, Barcelona, Spain
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self, spectrogram, filterbank=HPCP, num_classes=HPCP.CLASSES,
                  fmin=HPCP.FMIN, fmax=HPCP.FMAX, fref=A4, window=HPCP.WINDOW,

--- a/madmom/audio/comb_filters.pyx
+++ b/madmom/audio/comb_filters.pyx
@@ -1,6 +1,7 @@
 # encoding: utf-8
+
 """
-This file contains the speed crucial filter and filterbank functionality.
+This file contains comb-filter and comb-filterbank functionality.
 
 """
 

--- a/madmom/audio/ffmpeg.py
+++ b/madmom/audio/ffmpeg.py
@@ -1,5 +1,10 @@
 # encoding: utf-8
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
+This file contains audio handling via ffmpeg functionality.
+
 """
 
 import tempfile

--- a/madmom/audio/filters.py
+++ b/madmom/audio/filters.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains filter and filterbank related functionality.
 
@@ -283,6 +287,9 @@ class Filter(np.ndarray):
     Generic filter class.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self, data, start=0, norm=False):
         """
@@ -373,6 +380,10 @@ class TriangularFilter(Filter):
     Triangular filter class.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
+
     def __init__(self, start, center, stop, norm=False):
         """
         Creates a new TriangularFilter instance.
@@ -389,6 +400,8 @@ class TriangularFilter(Filter):
         # the initialisation is done in __new__() and __array_finalize__()
 
     def __new__(cls, start, center, stop, norm=False):
+        # pylint: disable=arguments-differ
+
         # center must be between start & stop
         if not start <= center < stop:
             raise ValueError('center must be between start and stop')
@@ -436,6 +449,8 @@ class TriangularFilter(Filter):
               applies.
 
         """
+        # pylint: disable=arguments-differ
+
         # make sure enough bins are given
         if len(bins) < 3:
             raise ValueError('not enough bins to create a TriangularFilter')
@@ -464,6 +479,9 @@ class RectangularFilter(Filter):
     Rectangular filter class.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self, start, stop, norm=False):
         """
@@ -480,6 +498,8 @@ class RectangularFilter(Filter):
         # the initialisation is done in __new__() and __array_finalize__()
 
     def __new__(cls, start, stop, norm=False):
+        # pylint: disable=signature-differs
+
         # start must be smaller than stop
         if start >= stop:
             raise ValueError('start must be smaller than stop')
@@ -501,6 +521,8 @@ class RectangularFilter(Filter):
         :return:        start and stop bins
 
         """
+        # pylint: disable=arguments-differ
+
         # make sure enough bins are given
         if len(bins) < 2:
             raise ValueError('not enough bins to create a RectangularFilter')
@@ -537,6 +559,10 @@ class Filterbank(np.ndarray):
     num_bands).
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
+
     fref = None
 
     def __init__(self, data, bin_frequencies):
@@ -645,7 +671,7 @@ class Filterbank(np.ndarray):
             band = fb[:, band_id]
             # if there's a list of filters for the current band, put them all
             # into this band
-            if type(band_filter) is list:
+            if isinstance(band_filter, list):
                 for filt in band_filter:
                     cls._put_filter(filt, band)
             # otherwise put this filter into that band
@@ -724,6 +750,10 @@ class MelFilterbank(Filterbank):
     Mel filterbank class.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
+
     NUM_BANDS = 40
     FMIN = 20.
     FMAX = 17000.
@@ -756,6 +786,8 @@ class MelFilterbank(Filterbank):
     def __new__(cls, bin_frequencies, num_bands=NUM_BANDS, fmin=FMIN,
                 fmax=FMAX, norm_filters=NORM_FILTERS,
                 unique_filters=UNIQUE_FILTERS, **kwargs):
+        # pylint: disable=unused-argument
+
         # get a list of frequencies aligned on the Mel scale
         # request 2 more bands, because these are the edge frequencies
         frequencies = mel_frequencies(num_bands + 2, fmin, fmax)
@@ -774,6 +806,10 @@ class BarkFilterbank(Filterbank):
     Bark filterbank class.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
+
     FMIN = 20.
     FMAX = 15500.
     NUM_BANDS = 'normal'
@@ -802,6 +838,8 @@ class BarkFilterbank(Filterbank):
     def __new__(cls, bin_frequencies, num_bands=NUM_BANDS, fmin=FMIN,
                 fmax=FMAX, norm_filters=NORM_FILTERS,
                 unique_filters=UNIQUE_FILTERS, **kwargs):
+        # pylint: disable=unused-argument
+
         # get a list of frequencies
         if num_bands == 'normal':
             frequencies = bark_frequencies(fmin, fmax)
@@ -824,6 +862,10 @@ class LogarithmicFilterbank(Filterbank):
     Logarithmic filterbank class.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
+
     NUM_BANDS_PER_OCTAVE = 12
 
     def __init__(self, bin_frequencies, num_bands=NUM_BANDS_PER_OCTAVE,
@@ -859,6 +901,8 @@ class LogarithmicFilterbank(Filterbank):
     def __new__(cls, bin_frequencies, num_bands=NUM_BANDS_PER_OCTAVE,
                 fmin=FMIN, fmax=FMAX, fref=A4, norm_filters=NORM_FILTERS,
                 unique_filters=UNIQUE_FILTERS, bands_per_octave=True):
+        # pylint: disable=arguments-differ
+
         # decide whether num_bands is bands per octave or total number of bands
         if bands_per_octave:
             num_bands_per_octave = num_bands
@@ -916,6 +960,9 @@ class RectangularFilterbank(Filterbank):
     Rectangular filterbank class.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self, bin_frequencies, crossover_frequencies, fmin=FMIN,
                  fmax=FMAX, norm_filters=NORM_FILTERS,
@@ -941,6 +988,8 @@ class RectangularFilterbank(Filterbank):
     def __new__(cls, bin_frequencies, crossover_frequencies, fmin=FMIN,
                 fmax=FMAX, norm_filters=NORM_FILTERS,
                 unique_filters=UNIQUE_FILTERS):
+        # pylint: disable=arguments-differ
+
         # create an empty filterbank
         fb = np.zeros((len(bin_frequencies), len(crossover_frequencies) + 1),
                       dtype=FILTER_DTYPE)
@@ -986,6 +1035,10 @@ class SimpleChromaFilterbank(Filterbank):
     A simple chroma filterbank based on a (semitone) filterbank.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
+
     NUM_BANDS = 12
 
     def __init__(self, bin_frequencies, num_bands=NUM_BANDS, fmin=FMIN,
@@ -1010,6 +1063,8 @@ class SimpleChromaFilterbank(Filterbank):
     def __new__(cls, bin_frequencies, num_bands=NUM_BANDS, fmin=FMIN,
                 fmax=FMAX, fref=A4, norm_filters=NORM_FILTERS,
                 unique_filters=UNIQUE_FILTERS):
+        # pylint: disable=arguments-differ
+
         raise NotImplementedError("please check if produces correct/expected "
                                   "results and enable if yes.")
         # TODO: add comments!
@@ -1078,6 +1133,10 @@ class PitchClassProfileFilterbank(Filterbank):
     Beijing, China
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
+
     CLASSES = 12
     FMIN = 100.
     FMAX = 5000.
@@ -1099,6 +1158,8 @@ class PitchClassProfileFilterbank(Filterbank):
 
     def __new__(cls, bin_frequencies, num_classes=CLASSES, fmin=FMIN,
                 fmax=FMAX, fref=A4):
+        # pylint: disable=arguments-differ
+
         # init a filterbank
         fb = np.zeros((len(bin_frequencies), num_classes))
         # use only positive bin frequencies
@@ -1159,6 +1220,10 @@ class HarmonicPitchClassProfileFilterbank(PitchClassProfileFilterbank):
     PhD thesis, Universitat Pompeu Fabra, Barcelona, Spain
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
+
     CLASSES = 36
     FMIN = 100.
     FMAX = 5000.
@@ -1182,6 +1247,8 @@ class HarmonicPitchClassProfileFilterbank(PitchClassProfileFilterbank):
 
     def __new__(cls, bin_frequencies, num_classes=CLASSES, fmin=FMIN,
                 fmax=FMAX, fref=A4, window=WINDOW):
+        # pylint: disable=arguments-differ
+
         # init a filterbank
         fb = np.zeros((len(bin_frequencies), num_classes))
         # use only positive bin frequencies

--- a/madmom/audio/hpss.py
+++ b/madmom/audio/hpss.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains all harmonic/percussive source separation functionality.
 

--- a/madmom/audio/spectrogram.py
+++ b/madmom/audio/spectrogram.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains spectrogram related functionality.
 
@@ -118,6 +122,9 @@ class Spectrogram(PropertyMixin, np.ndarray):
     Spectrogram class.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self, stft, **kwargs):
         """
@@ -202,6 +209,9 @@ class Spectrogram(PropertyMixin, np.ndarray):
         Determines the tuning frequency of the audio signal based on peaks
         of the spectrogram.
 
+        :param kwargs: keyword arguments passed to tuning_frequency()
+        :return:       tuning frequency of the spectrogram
+
         """
         from scipy.ndimage.filters import maximum_filter
         # widen the spectrogram in frequency dimension
@@ -247,6 +257,10 @@ class FilteredSpectrogram(Spectrogram):
     FilteredSpectrogram class.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
+
     # we just want to inherit some properties from Spectrogram
 
     def __init__(self, spectrogram, filterbank=FILTERBANK, num_bands=NUM_BANDS,
@@ -292,6 +306,8 @@ class FilteredSpectrogram(Spectrogram):
     def __new__(cls, spectrogram, filterbank=FILTERBANK, num_bands=NUM_BANDS,
                 fmin=FMIN, fmax=FMAX, fref=A4, norm_filters=NORM_FILTERS,
                 unique_filters=UNIQUE_FILTERS, block_size=2048, **kwargs):
+        # pylint: disable=unused-argument
+
         import inspect
         from .filters import Filterbank
 
@@ -396,6 +412,8 @@ class FilteredSpectrogramProcessor(Processor):
                                at low frequencies [bool]
 
         """
+        # pylint: disable=unused-argument
+
         self.filterbank = filterbank
         self.num_bands = num_bands
         self.fmin = fmin
@@ -517,6 +535,10 @@ class LogarithmicSpectrogram(Spectrogram):
     LogarithmicSpectrogram class.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
+
     # we just want to inherit some properties from Spectrogram
 
     def __init__(self, spectrogram, mul=MUL, add=ADD, **kwargs):
@@ -608,6 +630,8 @@ class LogarithmicSpectrogramProcessor(Processor):
                     magnitudes [float]
 
         """
+        # pylint: disable=unused-argument
+
         self.mul = mul
         self.add = add
 
@@ -670,6 +694,9 @@ class LogarithmicFilteredSpectrogram(LogarithmicSpectrogram,
     LogarithmicFilteredSpectrogram class.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self, spectrogram, **kwargs):
         """
@@ -753,6 +780,8 @@ class LogarithmicFilteredSpectrogramProcessor(Processor):
                                the magnitudes [float]
 
         """
+        # pylint: disable=unused-argument
+
         self.filterbank = filterbank
         self.num_bands = num_bands
         self.fmin = fmin
@@ -793,6 +822,10 @@ class SpectrogramDifference(Spectrogram):
     SpectrogramDifference class.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
+
     # we just want to inherit some properties from Spectrogram
 
     def __init__(self, spectrogram, diff_ratio=DIFF_RATIO,
@@ -944,6 +977,8 @@ class SpectrogramDifferenceProcessor(Processor):
                                diff values < 0 to 0
 
         """
+        # pylint: disable=unused-argument
+
         self.diff_ratio = diff_ratio
         self.diff_frames = diff_frames
         self.diff_max_bins = diff_max_bins
@@ -1080,6 +1115,9 @@ class MultiBandSpectrogram(FilteredSpectrogram):
     MultiBandSpectrogram class.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=super-init-not-called
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self, spectrogram, crossover_frequencies, norm_bands=False,
                  **kwargs):
@@ -1144,7 +1182,7 @@ class MultiBandSpectrogram(FilteredSpectrogram):
         # needed for correct pickling
         # source: http://stackoverflow.com/questions/26598109/
         # get the parent's __reduce__ tuple
-        pickled_state = super(FilteredSpectrogram, self).__reduce__()
+        pickled_state = super(MultiBandSpectrogram, self).__reduce__()
         # create our own tuple to pass to __setstate__
         new_state = pickled_state[2] + (self.filterbank,
                                         self.crossover_frequencies,
@@ -1159,7 +1197,7 @@ class MultiBandSpectrogram(FilteredSpectrogram):
         self.crossover_frequencies = state[-2]
         self.norm_bands = state[-1]
         # call the parent's __setstate__ with the other tuple elements
-        super(FilteredSpectrogram, self).__setstate__(state[0:-3])
+        super(MultiBandSpectrogram, self).__setstate__(state[0:-3])
 
     @property
     def bin_frequencies(self):
@@ -1183,6 +1221,8 @@ class MultiBandSpectrogramProcessor(Processor):
         :param norm_bands:            normalize the bands [bool]
 
         """
+        # pylint: disable=unused-argument
+
         self.crossover_frequencies = crossover_frequencies
         self.norm_bands = norm_bands
 
@@ -1244,6 +1284,7 @@ class StackedSpectrogramProcessor(ParallelProcessor):
     dimension.
 
     """
+
     # Note: `frame_size` is used instead of the more meaningful `frame_sizes`,
     #       this way the existing argument from `FramedSignal` can be reused
     def __init__(self, frame_size, spectrogram, difference=None,
@@ -1328,6 +1369,8 @@ class StackedSpectrogramProcessor(ParallelProcessor):
 
 
         """
+        # pylint: disable=arguments-differ
+
         # add diff related options to the existing parser
         g = parser.add_argument_group('stacking arguments')
         # stacking axis

--- a/madmom/audio/stft.py
+++ b/madmom/audio/stft.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains Short-Time Fourier Transform (STFT) related functionality.
 
@@ -176,6 +180,7 @@ class ShortTimeFourierTransform(PropertyMixin, np.ndarray):
     ShortTimeFourierTransform class.
 
     """
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self, frames, window=np.hanning, fft_size=None,
                  circular_shift=False, **kwargs):
@@ -212,6 +217,8 @@ class ShortTimeFourierTransform(PropertyMixin, np.ndarray):
 
     def __new__(cls, frames, window=np.hanning, fft_size=None,
                 circular_shift=False, **kwargs):
+        # pylint: disable=unused-argument
+
         from .signal import FramedSignal
         # take the FramedSignal from the given STFT
         if isinstance(frames, ShortTimeFourierTransform):
@@ -331,6 +338,8 @@ class ShortTimeFourierTransformProcessor(Processor):
                                FFT; needed for correct phase
 
         """
+        # pylint: disable=unused-argument
+
         self.window = window
         self.fft_size = fft_size
         self.circular_shift = circular_shift
@@ -387,6 +396,7 @@ class Phase(PropertyMixin, np.ndarray):
     Phase class.
 
     """
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self, stft, **kwargs):
         """
@@ -405,6 +415,8 @@ class Phase(PropertyMixin, np.ndarray):
         # the initialisation is done in __new__() and __array_finalize__()
 
     def __new__(cls, stft, **kwargs):
+        # pylint: disable=unused-argument
+
         # if a Phase object is given use its STFT
         if isinstance(stft, Phase):
             stft = stft.stft
@@ -454,6 +466,7 @@ class LocalGroupDelay(PropertyMixin, np.ndarray):
     Local Group Delay class.
 
     """
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self, phase, **kwargs):
         """
@@ -472,6 +485,8 @@ class LocalGroupDelay(PropertyMixin, np.ndarray):
         # the initialisation is done in __new__() and __array_finalize__()
 
     def __new__(cls, phase, **kwargs):
+        # pylint: disable=unused-argument
+
         # try to instantiate a Phase object
         if not isinstance(stft, Phase):
             phase = Phase(phase, circular_shift=True, **kwargs)

--- a/madmom/evaluation/__init__.py
+++ b/madmom/evaluation/__init__.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 Evaluation package.
 
@@ -643,6 +647,8 @@ def tostring(eval_objects, metric_names=None, float_format='{:.3f}', **kwargs):
           evaluation object.
 
     """
+    # pylint: disable=unused-argument
+
     return '\n'.join([e.tostring() for e in eval_objects])
 
 
@@ -662,6 +668,8 @@ def tocsv(eval_objects, metric_names=None, float_format='{:.3f}', **kwargs):
           evaluation object.
 
     """
+    # pylint: disable=unused-argument
+
     if metric_names is None:
         # get the evaluation metrics from the first evaluation object
         metric_names = eval_objects[0].METRIC_NAMES
@@ -693,6 +701,8 @@ def totex(eval_objects, metric_names=None, float_format='{:.3f}', **kwargs):
           evaluation object.
 
     """
+    # pylint: disable=unused-argument
+
     if metric_names is None:
         # get the evaluation metrics from the first evaluation object
         metric_names = eval_objects[0].METRIC_NAMES

--- a/madmom/evaluation/alignment.py
+++ b/madmom/evaluation/alignment.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains global alignment evaluation functionality.
 
@@ -267,6 +271,7 @@ class AlignmentEvaluation(EvaluationABC):
         :param kwargs:        additional arguments will be ignored
 
         """
+        # pylint: disable=unused-argument
 
         alignment = load_alignment(alignment)
         ground_truth = load_alignment(ground_truth)

--- a/madmom/evaluation/beats.py
+++ b/madmom/evaluation/beats.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This software serves as a Python implementation of the beat evaluation toolkit,
 which can be downloaded from:

--- a/madmom/evaluation/notes.py
+++ b/madmom/evaluation/notes.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains note evaluation functionality.
 

--- a/madmom/evaluation/onsets.py
+++ b/madmom/evaluation/onsets.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains onset evaluation functionality.
 

--- a/madmom/evaluation/tempo.py
+++ b/madmom/evaluation/tempo.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains tempo evaluation functionality.
 
@@ -188,6 +192,8 @@ class TempoEvaluation(EvaluationABC):
               on the `sort` this can be either the first or the strongest one.
 
         """
+        # pylint: disable=unused-argument
+
         # load the tempo detections and annotations
         detections = load_tempo(detections, sort=sort, max_len=max_len)
         annotations = load_tempo(annotations, sort=sort, max_len=max_len)
@@ -228,6 +234,8 @@ class TempoEvaluation(EvaluationABC):
         :return:       evaluation metrics formatted as a human readable string
 
         """
+        # pylint: disable=unused-argument
+
         ret = ''
         if self.name is not None:
             ret += '%s\n  ' % self.name

--- a/madmom/features/__init__.py
+++ b/madmom/features/__init__.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This package includes higher level features. Your definition of "higher" may
 vary, but all "lower" level features can be found the `audio` package.
@@ -16,8 +20,10 @@ class Activations(np.ndarray):
     attribute.
 
     """
+    # pylint: disable=super-on-old-class
+    # pylint: disable=attribute-defined-outside-init
 
-    def __new__(cls, data, fps=None, sep=None, dtype=np.float32):
+    def __init__(self, data, fps=None, sep=None, dtype=np.float32):
         """
         Instantiate a new Activations object.
 
@@ -36,6 +42,10 @@ class Activations(np.ndarray):
               The activations are stored/saved/kept as np.float32.
 
         """
+        # this method exists only for argument documentation purposes
+        # the initialisation is done in __new__() and __array_finalize__()
+
+    def __new__(cls, data, fps=None, sep=None, dtype=np.float32):
         # check the type of the given data
         if isinstance(data, np.ndarray):
             # cast to Activations
@@ -144,8 +154,8 @@ class Activations(np.ndarray):
                    'fps': self.fps}
             np.savez(outfile, **npz)
         else:
-            if self.ndim >2:
-                raise ValueError('Only 1d and 2d activations can pre saved in '
+            if self.ndim > 2:
+                raise ValueError('Only 1D and 2D activations can be saved in '
                                  'human readable text format.')
             # simple text format
             header = "FPS:%f" % self.fps
@@ -172,6 +182,8 @@ class ActivationsProcessor(Processor):
               Only binary files can store the frame rate of the activations.
 
         """
+        # pylint: disable=unused-argument
+
         self.mode = mode
         self.fps = fps
         self.sep = sep
@@ -187,6 +199,8 @@ class ActivationsProcessor(Processor):
         :return:       Activations instance
 
         """
+        # pylint: disable=arguments-differ
+
         if self.mode in ('r', 'in', 'load'):
             return Activations.load(data, fps=self.fps, sep=self.sep)
         if self.mode in ('w', 'out', 'save'):

--- a/madmom/features/beats.py
+++ b/madmom/features/beats.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains all beat tracking related functionality.
 
@@ -33,6 +37,8 @@ class MultiModelSelectionProcessor(Processor):
         Retrieval Conference (ISMIR), 2014
 
         """
+        # pylint: disable=unused-argument
+
         self.num_ref_predictions = num_ref_predictions
 
     def process(self, predictions):
@@ -378,8 +384,11 @@ def _process_crf(process_tuple):
                           and log probability of beat sequence
 
     """
+    # pylint: disable=no-name-in-module
+
+    from .beats_crf import best_sequence
     # activations, dominant_interval, interval_sigma = process_tuple
-    return CRFBeatDetectionProcessor.best_sequence(*process_tuple)
+    return best_sequence(*process_tuple)
 
 
 class CRFBeatDetectionProcessor(BeatTrackingProcessor):
@@ -389,22 +398,13 @@ class CRFBeatDetectionProcessor(BeatTrackingProcessor):
     """
     INTERVAL_SIGMA = 0.18
     USE_FACTORS = False
-    FACTORS = [0.5, 0.67, 1.0, 1.5, 2.0]
+    FACTORS = np.array([0.5, 0.67, 1.0, 1.5, 2.0])
     NUM_INTERVALS = 5
     # tempo defaults
     MIN_BPM = 20
     MAX_BPM = 240
     ACT_SMOOTH = 0.09
     HIST_SMOOTH = 7
-
-    try:
-        from .beats_crf import best_sequence
-    except ImportError:
-        import warnings
-        warnings.warn('CRFBeatDetection only works if you build the viterbi '
-                      'module with cython!')
-        # else, use dummy function
-        best_sequence = lambda x: np.array([]), -np.inf
 
     def __init__(self, interval_sigma=INTERVAL_SIGMA, use_factors=USE_FACTORS,
                  num_intervals=NUM_INTERVALS, factors=FACTORS, **kwargs):
@@ -514,6 +514,8 @@ class CRFBeatDetectionProcessor(BeatTrackingProcessor):
         :return:               beat argument parser group
 
         """
+        # pylint: disable=arguments-differ
+
         from madmom.utils import OverrideDefaultListAction
         # add CRF related arguments
         g = parser.add_argument_group('conditional random field arguments')
@@ -521,18 +523,16 @@ class CRFBeatDetectionProcessor(BeatTrackingProcessor):
                        default=interval_sigma,
                        help='allowed deviation from the dominant interval '
                             '[default=%(default).2f]')
-
         g.add_argument('--use_factors', action='store_true',
                        default=use_factors,
                        help='use dominant interval multiplied with factors '
                             'instead of multiple estimated intervals '
                             '[default=%(default)s]')
-
         g.add_argument('--num_intervals', action='store', type=int,
                        default=num_intervals, dest='num_intervals',
                        help='number of estimated intervals to try '
                             '[default=%(default)s]')
-        g.add_argument('-f', '--factors', action=OverrideDefaultListAction,
+        g.add_argument('--factors', action=OverrideDefaultListAction,
                        default=factors, type=float, sep=',',
                        help='(comma separated) list with factors of dominant '
                             'interval to try [default=%(default)s]')
@@ -552,6 +552,8 @@ class CRFBeatDetectionProcessor(BeatTrackingProcessor):
         :return:            tempo argument parser group
 
         """
+        # pylint: disable=arguments-differ
+
         # TODO: import the TempoEstimation here otherwise we have a
         #       loop. This is super ugly, but right now I can't think of a
         #       better solution...
@@ -622,6 +624,8 @@ class DBNBeatTrackingProcessor(Processor):
         Retrieval Conference (ISMIR), 2015.
 
         """
+        # pylint: disable=unused-argument
+        # pylint: disable=no-name-in-module
 
         from madmom.ml.hmm import HiddenMarkovModel as Hmm
         from .beats_hmm import (BeatTrackingStateSpace as St,
@@ -722,6 +726,8 @@ class DBNBeatTrackingProcessor(Processor):
         :return:                   beat argument parser group
 
         """
+        # pylint: disable=arguments-differ
+
         # add DBN parser group
         g = parser.add_argument_group('dynamic Bayesian Network arguments')
         if correct:
@@ -773,6 +779,7 @@ class DownbeatTrackingProcessor(Processor):
     Beat and downbeat tracking with a dynamic Bayesian network (DBN).
 
     """
+    # TODO: this should not be lists (lists are mutable!)
     MIN_BPM = [55, 60]
     MAX_BPM = [205, 225]
     NUM_TEMPO_STATES = [None, None]
@@ -836,6 +843,8 @@ class DownbeatTrackingProcessor(Processor):
         Retrieval Conference (ISMIR), 2015.
 
         """
+        # pylint: disable=unused-argument
+        # pylint: disable=no-name-in-module
 
         from madmom.ml.hmm import HiddenMarkovModel as Hmm
         from .beats_hmm import (DownBeatTrackingStateSpace as St,

--- a/madmom/features/beats_crf.pyx
+++ b/madmom/features/beats_crf.pyx
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 """
 This file contains the speed crucial Viterbi functionality for the
 CRFBeatDetector plus some functions computing the distributions and

--- a/madmom/features/beats_hmm.pyx
+++ b/madmom/features/beats_hmm.pyx
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 """
 This file contains HMM state space, transition and observation models used for
 beat and downbeat tracking.

--- a/madmom/features/notes.py
+++ b/madmom/features/notes.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains note transcription related functionality.
 

--- a/madmom/features/onsets.py
+++ b/madmom/features/onsets.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains onset detection related functionality.
 
@@ -446,6 +450,8 @@ class SpectralOnsetProcessor(Processor):
         :param onset_method:        onset detection function
 
         """
+        # pylint: disable=unused-argument
+
         self.method = onset_method
 
     def process(self, spectrogram):
@@ -604,6 +610,8 @@ class PeakPickingProcessor(Processor):
         Retrieval Conference (ISMIR), 2012.
 
         """
+        # pylint: disable=unused-argument
+
         # # make this an IOProcessor by defining input and output processings
         # super(PeakPicking, self).__init__(peak_picking, write_events)
         # adjust some params for online mode

--- a/madmom/features/tempo.py
+++ b/madmom/features/tempo.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains tempo related functionality.
 
@@ -199,6 +203,8 @@ class TempoEstimationProcessor(Processor):
         :param alpha:       scaling factor for the comb filter
 
         """
+        # pylint: disable=unused-argument
+
         # save variables
         self.method = method
         self.min_bpm = min_bpm

--- a/madmom/ml/__init__.py
+++ b/madmom/ml/__init__.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 """
 Machine learning package.
 

--- a/madmom/ml/gmm.py
+++ b/madmom/ml/gmm.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains functionality needed for fitting and scoring Gaussian
 Mixture Models (GMMs) (needed e.g. in madmom.features.dbn).
@@ -134,10 +138,10 @@ def log_multivariate_normal_density(x, means, covars, covariance_type='diag'):
 def _log_multivariate_normal_density_diag(x, means, covars):
     """Compute Gaussian log-density at x for a diagonal model."""
     n_samples, n_dim = x.shape
-    lpr = -0.5 * (n_dim * np.log(2 * np.pi) + np.sum(np.log(covars), 1)
-                  + np.sum((means ** 2) / covars, 1)
-                  - 2 * np.dot(x, (means / covars).T)
-                  + np.dot(x ** 2, (1.0 / covars).T))
+    lpr = -0.5 * (n_dim * np.log(2 * np.pi) + np.sum(np.log(covars), 1) +
+                  np.sum((means ** 2) / covars, 1) -
+                  2 * np.dot(x, (means / covars).T) +
+                  np.dot(x ** 2, (1.0 / covars).T))
     return lpr
 
 

--- a/madmom/ml/hmm.pyx
+++ b/madmom/ml/hmm.pyx
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 """
 This file contains Hidden Markov Model (HMM) functionality.
 

--- a/madmom/ml/io.py
+++ b/madmom/ml/io.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains functionality needed for the conversion of from the
 universal .h5 format to the .npz format understood by madmom.ml.rnn.

--- a/madmom/ml/rnn.py
+++ b/madmom/ml/rnn.py
@@ -1,4 +1,9 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+# pylint: disable=too-few-public-methods
+
 """
 This file contains recurrent neural network (RNN) related functionality.
 
@@ -14,8 +19,8 @@ Just use one of the many NN/ML packages out there if you need training or any
 other stuff.
 
 """
-import abc
 
+import abc
 import numpy as np
 
 from ..processors import Processor, ParallelProcessor
@@ -67,6 +72,8 @@ def _sigmoid(x, out=None):
     return out
 
 try:
+    # pylint: disable=no-name-in-module
+
     # try to use a faster sigmoid function
     from distutils.version import LooseVersion
     from scipy.version import version as scipy_version
@@ -533,6 +540,8 @@ class RNNProcessor(ParallelProcessor):
         :param num_threads: number of parallel working threads
 
         """
+        # pylint: disable=unused-argument
+
         nn_models = []
         for nn_file in nn_files:
             nn_models.append(RecurrentNeuralNetwork.load(nn_file))
@@ -549,6 +558,8 @@ class RNNProcessor(ParallelProcessor):
         :return:         neural network argument parser group
 
         """
+        # pylint: disable=signature-differs
+
         from madmom.utils import OverrideDefaultListAction
         # add neural network options
         g = parser.add_argument_group('neural network arguments')

--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains all processor related functionality.
 
@@ -394,16 +398,19 @@ class IOProcessor(OutputProcessor):
         return _process((self.out_processor, data, output))
 
 
-def process_single(processor, input, output, **kwargs):
+def process_single(processor, infile, outfile, **kwargs):
     """
     Process a single file with the given Processor.
 
     :param processor: pickled Processor
-    :param input:     input audio file
-    :param output:    output file
+    :param infile:    input file or file handle
+    :param outfile:   outfile file or file handle
+    :param kwargs:    additional keyword arguments will be ignored
 
     """
-    processor.process(input, output)
+    # pylint: disable=unused-argument
+
+    processor.process(infile, outfile)
 
 
 class ParallelProcess(mp.Process):
@@ -447,10 +454,13 @@ def process_batch(processor, files, output_dir=None, output_suffix=None,
     :param output_suffix: output suffix
     :param strip_ext:     strip off the extension from the files [bool]
     :param num_workers:   number of parallel working threads [int]
+    :param kwargs:        additional keyword arguments will be ignored
 
     Note: Either `output_dir` or `output_suffix` must be set.
 
     """
+    # pylint: disable=unused-argument
+
     # either output_dir or output_suffix must be given
     if output_dir is None and output_suffix is None:
         raise ValueError('either output directory or suffix must be given')
@@ -497,8 +507,11 @@ def pickle_processor(processor, outfile, **kwargs):
 
     :param processor: the Processor
     :param outfile:   file where to pickle it
+    :param kwargs:    additional keyword arguments will be ignored
 
     """
+    # pylint: disable=unused-argument
+
     processor.dump(outfile)
 
 
@@ -523,9 +536,9 @@ def io_arguments(parser, output_suffix='.txt'):
     # single file processing options
     sp = sub_parsers.add_parser('single', help='single file processing')
     sp.set_defaults(func=process_single)
-    sp.add_argument('input', type=argparse.FileType('r'),
+    sp.add_argument('infile', type=argparse.FileType('r'),
                     help='input audio file')
-    sp.add_argument('output', nargs='?',
+    sp.add_argument('outfile', nargs='?',
                     type=argparse.FileType('w'), default=sys.stdout,
                     help='output file [default: STDOUT]')
     sp.add_argument('-j', dest='num_threads', type=int, default=mp.cpu_count(),

--- a/madmom/utils/__init__.py
+++ b/madmom/utils/__init__.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 Utility package.
 
@@ -6,7 +10,6 @@ Utility package.
 
 import argparse
 import contextlib
-
 import numpy as np
 
 
@@ -116,7 +119,6 @@ def search_files(path, suffix=None):
     file_list.sort()
     # return the file list
     return file_list
-
 
 
 def strip_suffix(filename, suffix=None):

--- a/madmom/utils/midi.py
+++ b/madmom/utils/midi.py
@@ -1,4 +1,9 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+# pylint: disable=too-few-public-methods
+
 """
 This file contains MIDI functionality.
 
@@ -197,7 +202,7 @@ class AbstractEvent(object):
     register = False
 
     def __init__(self, **kwargs):
-        if type(self.length) == int:
+        if isinstance(self.length, int):
             data = [0] * self.length
         else:
             data = []
@@ -1037,8 +1042,8 @@ class MIDITrack(object):
             e_on.velocity = int(notes[note, 3])
             # and NoteOff
             e_off = NoteOffEvent()
-            e_off.tick = int((notes[note, 0] + notes[note, 2])
-                             * resolution * bps)
+            e_off.tick = int((notes[note, 0] + notes[note, 2]) *
+                             resolution * bps)
             e_off.pitch = int(notes[note, 1])
             events.append(e_on)
             events.append(e_off)
@@ -1190,14 +1195,16 @@ class MIDIFile(object):
             for e in note_events:
                 if tick > e.tick:
                     raise AssertionError('note events must be sorted!')
+
+                is_note_on = isinstance(e, NoteOnEvent)
+                is_note_off = isinstance(e, NoteOffEvent)
                 # if it's a note on event with a velocity > 0,
-                if isinstance(e, NoteOnEvent) and e.velocity > 0:
+                if is_note_on and e.velocity > 0:
                     # save the onset time and velocity
                     note_onsets[e.pitch] = e.tick
                     note_velocities[e.pitch] = e.velocity
                 # if it's a note off event or a note on with a velocity of 0,
-                elif isinstance(e, NoteOffEvent) or (isinstance(e, NoteOnEvent)
-                                                     and e.velocity == 0):
+                elif is_note_off or (is_note_on and e.velocity == 0):
                     # the old velocity must be greater 0
                     if note_velocities[e.pitch] <= 0:
                         raise AssertionError('note velocity must be positive')

--- a/madmom/utils/stats.py
+++ b/madmom/utils/stats.py
@@ -1,4 +1,8 @@
 # encoding: utf-8
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-arguments
+
 """
 This file contains some statistical functionality.
 


### PR DESCRIPTION
Remove the `#!/usr/bin/env python` header from all files that are not callable.
Fix errors outlined by `pylint` and add directives to disable certain warnings.
