### PR TITLE
get_file_info now works with avprobe

### DIFF
--- a/madmom/audio/ffmpeg.py
+++ b/madmom/audio/ffmpeg.py
@@ -295,7 +295,10 @@ def get_file_info(infile, cmd='ffprobe'):
         if line.startswith(b'channels='):
             info['num_channels'] = int(line[len('channels='):])
         if line.startswith(b'sample_rate='):
-            info['sample_rate'] = int(line[len('sample_rate='):])
+            # the int(float(...)) conversion is necessary because
+            # avprobe returns sample_rate as floating point number
+            # which int() can't handle.
+            info['sample_rate'] = int(float(line[len('sample_rate='):]))
     # return the dictionary
     return info
 


### PR DESCRIPTION
Solves issue #54.

Made the cast explicitly only if the function is using `avprobe` so we can remove it if we decide to drop support for `avprobe`.