### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/madmom/__init__.py
+++ b/madmom/__init__.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import, division, print_function
 import os
 import pkg_resources
 
-MODELS_PATH = '%s/models' % (os.path.dirname(__file__))
+MODELS_PATH = '{0!s}/models'.format((os.path.dirname(__file__)))
 
 __version__ = pkg_resources.get_distribution("madmom").version
 

--- a/madmom/audio/cepstrogram.py
+++ b/madmom/audio/cepstrogram.py
@@ -222,8 +222,8 @@ class MFCC(Cepstrogram):
                                     norm_filters=norm_filters,
                                     duplicate_filters=False)
         if not isinstance(filterbank, Filterbank):
-            raise ValueError('not a Filterbank type or instance: %s' %
-                             filterbank)
+            raise ValueError('not a Filterbank type or instance: {0!s}'.format(
+                             filterbank))
         # filter the spectrogram
         data = np.dot(spectrogram, filterbank)
         # logarithmically scale the magnitudes

--- a/madmom/audio/chroma.py
+++ b/madmom/audio/chroma.py
@@ -110,8 +110,8 @@ class PitchClassProfile(FilteredSpectrogram):
                                     num_classes=num_classes, fmin=fmin,
                                     fmax=fmax, fref=fref)
         if not isinstance(filterbank, Filterbank):
-            raise ValueError('not a Filterbank type or instance: %s' %
-                             filterbank)
+            raise ValueError('not a Filterbank type or instance: {0!s}'.format(
+                             filterbank))
         # filter the spectrogram
         data = np.dot(spectrogram, filterbank)
         # cast as PitchClassProfile
@@ -193,8 +193,8 @@ class HarmonicPitchClassProfile(PitchClassProfile):
                                     num_classes=num_classes, fmin=fmin,
                                     fmax=fmax, fref=fref, window=window)
         if not isinstance(filterbank, Filterbank):
-            raise ValueError('not a Filterbank type or instance: %s' %
-                             filterbank)
+            raise ValueError('not a Filterbank type or instance: {0!s}'.format(
+                             filterbank))
         # filter the spectrogram
         data = np.dot(spectrogram, filterbank)
         # cast as PitchClassProfile

--- a/madmom/audio/ffmpeg.py
+++ b/madmom/audio/ffmpeg.py
@@ -60,8 +60,7 @@ def decode_to_disk(infile, fmt='f32le', sample_rate=None, num_channels=1,
     """
     # check input file type
     if not isinstance(infile, str):
-        raise ValueError("only file names are supported as `infile`, not %s."
-                         % infile)
+        raise ValueError("only file names are supported as `infile`, not {0!s}.".format(infile))
     # create temp file if no outfile is given
     if outfile is None:
         # looks stupid, but is recommended over tempfile.mktemp()
@@ -74,8 +73,7 @@ def decode_to_disk(infile, fmt='f32le', sample_rate=None, num_channels=1,
         delete_on_fail = False
     # check output file type
     if not isinstance(outfile, str):
-        raise ValueError("only file names are supported as `outfile`, not %s."
-                         % outfile)
+        raise ValueError("only file names are supported as `outfile`, not {0!s}.".format(outfile))
     # call ffmpeg (throws exception on error)
     try:
         call = _assemble_ffmpeg_call(infile, outfile, fmt, sample_rate,
@@ -121,8 +119,7 @@ def decode_to_memory(infile, fmt='f32le', sample_rate=None, num_channels=1,
     """
     # check input file type
     if not isinstance(infile, str):
-        raise ValueError("only file names are supported as `infile`, not %s."
-                         % infile)
+        raise ValueError("only file names are supported as `infile`, not {0!s}.".format(infile))
     # assemble ffmpeg call
     call = _assemble_ffmpeg_call(infile, "pipe:1", fmt, sample_rate,
                                  num_channels, skip, max_len, cmd)
@@ -180,8 +177,7 @@ def decode_to_pipe(infile, fmt='f32le', sample_rate=None, num_channels=1,
     """
     # check input file type
     if not isinstance(infile, str):
-        raise ValueError("only file names are supported as `infile`, not %s."
-                         % infile)
+        raise ValueError("only file names are supported as `infile`, not {0!s}.".format(infile))
     # Note: closing the file-like object only stops decoding because ffmpeg
     #       reacts on that. A cleaner solution would be calling
     #       proc.terminate explicitly, but this is only available in
@@ -250,11 +246,11 @@ def _assemble_ffmpeg_call(infile, output, fmt='f32le', sample_rate=None,
     # infile options
     if skip is not None:
         # use "%f" to avoid e-05 and the like
-        call.extend(["-ss", "%f" % float(skip)])
+        call.extend(["-ss", "{0:f}".format(float(skip))])
     call.extend(["-i", infile, "-y", "-f", str(fmt)])
     if max_len is not None:
         # use "%f" to avoid e-05 and the like
-        call.extend(["-t", "%f" % float(max_len)])
+        call.extend(["-t", "{0:f}".format(float(max_len))])
     # output options
     if num_channels is not None:
         call.extend(["-ac", str(int(num_channels))])
@@ -283,8 +279,7 @@ def get_file_info(infile, cmd='ffprobe'):
     """
     # check input file type
     if not isinstance(infile, str):
-        raise ValueError("only file names are supported as `infile`, not %s."
-                         % infile)
+        raise ValueError("only file names are supported as `infile`, not {0!s}.".format(infile))
     # init dictionary
     info = {'num_channels': None, 'sample_rate': None}
     # call ffprobe

--- a/madmom/audio/signal.py
+++ b/madmom/audio/signal.py
@@ -48,14 +48,14 @@ def smooth(signal, kernel):
             # use a Hamming window of given length
             kernel = np.hamming(kernel)
         else:
-            raise ValueError("can't create a smoothing kernel of size %d" %
-                             kernel)
+            raise ValueError("can't create a smoothing kernel of size {0:d}".format(
+                             kernel))
     # otherwise use the given smoothing kernel directly
     elif isinstance(kernel, np.ndarray):
         if len(kernel) > 1:
             kernel = kernel
     else:
-        raise ValueError("can't smooth signal with %s" % kernel)
+        raise ValueError("can't smooth signal with {0!s}".format(kernel))
     # convolve with the kernel and return
     if signal.ndim == 1:
         return np.convolve(signal, kernel, 'same')
@@ -367,7 +367,7 @@ def load_audio_file(filename, sample_rate=None, num_channels=None, start=None,
         # use the file name
         filename = filename.name
     # try reading as a wave file
-    error = "All attempts to load audio file %r failed." % filename
+    error = "All attempts to load audio file {0!r} failed.".format(filename)
     try:
         return load_wave_file(filename, sample_rate=sample_rate,
                               num_channels=num_channels, start=start,
@@ -833,8 +833,8 @@ class FramedSignal(object):
                 # return frames as long as the origin sample covers the signal
                 num_frames = np.ceil(len(self.signal) / float(self.hop_size))
             else:
-                raise ValueError("end of signal handling '%s' unknown" %
-                                 end)
+                raise ValueError("end of signal handling '{0!s}' unknown".format(
+                                 end))
         self.num_frames = int(num_frames)
 
     # make the object indexable / iterable

--- a/madmom/audio/spectrogram.py
+++ b/madmom/audio/spectrogram.py
@@ -385,8 +385,8 @@ class FilteredSpectrogram(Spectrogram):
                                     fref=fref, norm_filters=norm_filters,
                                     unique_filters=unique_filters)
         if not isinstance(filterbank, Filterbank):
-            raise TypeError('not a Filterbank type or instance: %s' %
-                            filterbank)
+            raise TypeError('not a Filterbank type or instance: {0!s}'.format(
+                            filterbank))
         # filter the spectrogram
         data = np.dot(spectrogram, filterbank)
         # cast as FilteredSpectrogram

--- a/madmom/evaluation/__init__.py
+++ b/madmom/evaluation/__init__.py
@@ -380,7 +380,7 @@ class SimpleEvaluation(EvaluationMixin):
         """
         ret = ''
         if self.name is not None:
-            ret += '%s\n  ' % self.name
+            ret += '{0!s}\n  '.format(self.name)
         ret += 'Annotations: %5d TP: %5d FP: %5d FN: %5d ' \
                'Precision: %.3f Recall: %.3f F-measure: %.3f Acc: %.3f' % \
                (self.num_annotations, self.num_tp, self.num_fp, self.num_fn,
@@ -542,9 +542,9 @@ class MultiClassEvaluation(Evaluation):
                 tn = self.tn[self.tn[:, 1] == cls]
                 fn = self.fn[self.fn[:, 1] == cls]
                 # evaluate them
-                e = Evaluation(tp, fp, tn, fn, name='Class %s' % cls)
+                e = Evaluation(tp, fp, tn, fn, name='Class {0!s}'.format(cls))
                 # append to the output string
-                ret += '  %s\n' % e.tostring(verbose=False)
+                ret += '  {0!s}\n'.format(e.tostring(verbose=False))
         # normal formatting
         ret += 'Annotations: %5d TP: %5d FP: %4d FN: %4d ' \
                'Precision: %.3f Recall: %.3f F-measure: %.3f Acc: %.3f' % \
@@ -576,7 +576,7 @@ class SumEvaluation(SimpleEvaluation):
             # wrap the given eval_object in a list
             eval_objects = [eval_objects]
         self.eval_objects = eval_objects
-        self.name = name or 'sum for %d files' % len(self)
+        self.name = name or 'sum for {0:d} files'.format(len(self))
 
     def __len__(self):
         # just use the length of the evaluation objects
@@ -627,7 +627,7 @@ class MeanEvaluation(SumEvaluation):
     def __init__(self, eval_objects, name=None, **kwargs):
         super(MeanEvaluation, self).__init__(eval_objects, **kwargs)
         # handle the 'name' here to be able to set a different default value
-        self.name = name or 'mean for %d files' % len(self)
+        self.name = name or 'mean for {0:d} files'.format(len(self))
 
     # overwrite the properties to calculate the mean instead of the sum
 
@@ -698,7 +698,7 @@ class MeanEvaluation(SumEvaluation):
         """
         ret = ''
         if self.name is not None:
-            ret += '%s\n  ' % self.name
+            ret += '{0!s}\n  '.format(self.name)
         # TODO: unify this with SimpleEvaluation but
         #       add option to provide field formatters (e.g. 3d or 5.2f)
         # format with floats instead of integers

--- a/madmom/evaluation/alignment.py
+++ b/madmom/evaluation/alignment.py
@@ -349,7 +349,7 @@ class AlignmentEvaluation(EvaluationMixin):
         """
         ret = ''
         if self.name is not None:
-            ret += '%s\n  ' % self.name
+            ret += '{0!s}\n  '.format(self.name)
 
         ret += 'misalign-rate: %.3f miss-rate: %.3f piece-compl.: %.3f '\
                'avg-imprecision: %.3f stddev-imprecision %.3f '\
@@ -417,7 +417,7 @@ class AlignmentSumEvaluation(AlignmentEvaluation):
     """
 
     def __init__(self, eval_objects, name=None):
-        self.name = name or 'piecewise mean for %d files' % len(eval_objects)
+        self.name = name or 'piecewise mean for {0:d} files'.format(len(eval_objects))
         self.window = eval_objects[0].window
         self._length = sum(len(e) for e in eval_objects)
 
@@ -442,7 +442,7 @@ class AlignmentMeanEvaluation(AlignmentEvaluation):
     """
 
     def __init__(self, eval_objects, name=None):
-        self.name = name or 'mean for %d files' % len(eval_objects)
+        self.name = name or 'mean for {0:d} files'.format(len(eval_objects))
         self.window = eval_objects[0].window
         self._length = len(eval_objects)
 

--- a/madmom/evaluation/beats.py
+++ b/madmom/evaluation/beats.py
@@ -936,8 +936,7 @@ def information_gain(detections, annotations, num_bins=INFORMATION_GAIN_BINS):
 
     # check if there are enough beat annotations for the number of bins
     if num_bins > len(annotations):
-        warnings.warn("Not enough beat annotations (%d) for %d histogram bins."
-                      % (len(annotations), num_bins))
+        warnings.warn("Not enough beat annotations ({0:d}) for {1:d} histogram bins.".format(len(annotations), num_bins))
 
     # create bins edges for the error histogram
     histogram_bins = _histogram_bins(num_bins)
@@ -1082,7 +1081,7 @@ class BeatEvaluation(OnsetEvaluation):
         """
         ret = ''
         if self.name is not None:
-            ret += '%s\n  ' % self.name
+            ret += '{0!s}\n  '.format(self.name)
         ret += 'F-measure: %.3f P-score: %.3f Cemgil: %.3f Goto: %.3f '\
                'CMLc: %.3f CMLt: %.3f AMLc: %.3f AMLt: %.3f D: %.3f '\
                'Dg: %.3f' % \
@@ -1174,7 +1173,7 @@ class BeatMeanEvaluation(MeanEvaluation):
         """
         ret = ''
         if self.name is not None:
-            ret += '%s\n  ' % self.name
+            ret += '{0!s}\n  '.format(self.name)
         ret += 'F-measure: %.3f P-score: %.3f Cemgil: %.3f Goto: %.3f '\
                'CMLc: %.3f CMLt: %.3f AMLc: %.3f AMLt: %.3f D: %.3f '\
                'Dg: %.3f' % \

--- a/madmom/evaluation/notes.py
+++ b/madmom/evaluation/notes.py
@@ -259,7 +259,7 @@ class NoteEvaluation(MultiClassEvaluation):
         """
         ret = ''
         if self.name is not None:
-            ret += '%s\n  ' % self.name
+            ret += '{0!s}\n  '.format(self.name)
         # add statistics for the individual note
         if notes:
             # determine which notes are present
@@ -277,10 +277,10 @@ class NoteEvaluation(MultiClassEvaluation):
                 # detections and annotations for this note (only onset times)
                 det = self.detections[self.detections[:, 1] == note][:, 0]
                 ann = self.annotations[self.annotations[:, 1] == note][:, 0]
-                name = 'MIDI note %s' % note
+                name = 'MIDI note {0!s}'.format(note)
                 e = OnsetEvaluation(det, ann, self.window, name=name)
                 # append to the output string
-                ret += '  %s\n' % e.tostring(notes=False)
+                ret += '  {0!s}\n'.format(e.tostring(notes=False))
         # normal formatting
         ret += 'Notes: %5d TP: %5d FP: %4d FN: %4d ' \
                'Precision: %.3f Recall: %.3f F-measure: %.3f ' \
@@ -338,7 +338,7 @@ class NoteMeanEvaluation(MeanEvaluation, NoteSumEvaluation):
         # format with floats instead of integers
         ret = ''
         if self.name is not None:
-            ret += '%s\n  ' % self.name
+            ret += '{0!s}\n  '.format(self.name)
         ret += 'Notes: %5.2f TP: %5.2f FP: %5.2f FN: %5.2f ' \
                'Precision: %.3f Recall: %.3f F-measure: %.3f ' \
                'Acc: %.3f mean: %5.1f ms std: %5.1f ms' % \

--- a/madmom/evaluation/onsets.py
+++ b/madmom/evaluation/onsets.py
@@ -249,7 +249,7 @@ class OnsetEvaluation(Evaluation):
         """
         ret = ''
         if self.name is not None:
-            ret += '%s\n  ' % self.name
+            ret += '{0!s}\n  '.format(self.name)
         ret += 'Onsets: %5d TP: %5d FP: %5d FN: %5d Precision: %.3f ' \
                'Recall: %.3f F-measure: %.3f mean: %5.1f ms std: %5.1f ms' % \
                (self.num_annotations, self.num_tp, self.num_fp, self.num_fn,
@@ -305,7 +305,7 @@ class OnsetMeanEvaluation(MeanEvaluation, OnsetSumEvaluation):
         # format with floats instead of integers
         ret = ''
         if self.name is not None:
-            ret += '%s\n  ' % self.name
+            ret += '{0!s}\n  '.format(self.name)
         ret += 'Onsets: %5.2f TP: %5.2f FP: %5.2f FN: %5.2f ' \
                'Precision: %.3f Recall: %.3f F-measure: %.3f ' \
                'mean: %5.1f ms std: %5.1f ms' % \

--- a/madmom/evaluation/tempo.py
+++ b/madmom/evaluation/tempo.py
@@ -278,7 +278,7 @@ class TempoEvaluation(EvaluationMixin):
 
         ret = ''
         if self.name is not None:
-            ret += '%s\n  ' % self.name
+            ret += '{0!s}\n  '.format(self.name)
         ret += 'pscore=%.3f (one tempo: %.3f, all tempi: %.3f) ' \
                'acc1=%.3f acc2=%.3f' % \
                (self.pscore, self.any, self.all, self.acc1, self.acc2)
@@ -332,7 +332,7 @@ class TempoMeanEvaluation(MeanEvaluation):
         """
         ret = ''
         if self.name is not None:
-            ret += '%s\n  ' % self.name
+            ret += '{0!s}\n  '.format(self.name)
         ret += 'pscore=%.3f (one tempo: %.3f, all tempi: %.3f) ' \
                'acc1=%.3f acc2=%.3f' % \
                (self.pscore, self.any, self.all, self.acc1, self.acc2)

--- a/madmom/features/__init__.py
+++ b/madmom/features/__init__.py
@@ -195,7 +195,7 @@ class Activations(np.ndarray):
                 raise ValueError('Only 1D and 2D activations can be saved in '
                                  'human readable text format.')
             # simple text format
-            header = "FPS:%f" % self.fps
+            header = "FPS:{0:f}".format(self.fps)
             np.savetxt(outfile, np.atleast_2d(self), fmt=fmt, delimiter=sep,
                        header=header)
 

--- a/madmom/features/notes.py
+++ b/madmom/features/notes.py
@@ -77,7 +77,7 @@ def expand_notes(notes, duration=0.6, velocity=100):
         new_columns = np.ones((rows, 2)) * velocity
         new_columns[:, 0] = duration
     else:
-        raise ValueError('unable to handle `notes` with %d columns' % columns)
+        raise ValueError('unable to handle `notes` with {0:d} columns'.format(columns))
     # return the notes
     notes = np.hstack((notes, new_columns))
     return notes

--- a/madmom/ml/gmm.py
+++ b/madmom/ml/gmm.py
@@ -243,8 +243,8 @@ class GMM(object):
     def __init__(self, n_components=1, covariance_type='full'):
 
         if covariance_type not in ['spherical', 'tied', 'diag', 'full']:
-            raise ValueError('Invalid value for covariance_type: %s' %
-                             covariance_type)
+            raise ValueError('Invalid value for covariance_type: {0!s}'.format(
+                             covariance_type))
         # save parameters
         self.n_components = n_components
         self.covariance_type = covariance_type

--- a/madmom/ml/io.py
+++ b/madmom/ml/io.py
@@ -69,16 +69,16 @@ def convert_model(infile, outfile=None, compressed=False):
     with h5py.File(infile, 'r') as h5:
         # model attributes
         for attr in list(h5['model'].attrs.keys()):
-            npz['model_%s' % attr] = h5['model'].attrs[attr]
+            npz['model_{0!s}'.format(attr)] = h5['model'].attrs[attr]
         # layers
         for l in list(h5['layer'].keys()):
             layer = h5['layer'][l]
             # each layer has some attributes
             for attr in list(layer.attrs.keys()):
-                npz['layer_%s_%s' % (l, attr)] = layer.attrs[attr]
+                npz['layer_{0!s}_{1!s}'.format(l, attr)] = layer.attrs[attr]
             # and some data sets (i.e. different weights)
             for data in list(layer.keys()):
-                npz['layer_%s_%s' % (l, data)] = layer[data].value
+                npz['layer_{0!s}_{1!s}'.format(l, data)] = layer[data].value
     # save the model to .npz format
     if outfile is None:
         outfile = os.path.splitext(infile)[0]

--- a/madmom/ml/rnn.py
+++ b/madmom/ml/rnn.py
@@ -539,17 +539,17 @@ class RecurrentNeuralNetwork(Processor):
             # first check if we need to create a bidirectional layer
             bwd_layer = None
 
-            if '%s_type' % REVERSE in list(params.keys()):
+            if '{0!s}_type'.format(REVERSE) in list(params.keys()):
                 # pop the parameters needed for the reverse (backward) layer
-                bwd_type = bytes(params.pop('%s_type' % REVERSE))
-                bwd_transfer_fn = bytes(params.pop('%s_transfer_fn' %
-                                                   REVERSE))
+                bwd_type = bytes(params.pop('{0!s}_type'.format(REVERSE)))
+                bwd_transfer_fn = bytes(params.pop('{0!s}_transfer_fn'.format(
+                                                   REVERSE)))
                 bwd_params = dict((k.split('_', 1)[1], params.pop(k))
                                   for k in list(params.keys()) if
-                                  k.startswith('%s_' % REVERSE))
+                                  k.startswith('{0!s}_'.format(REVERSE)))
                 bwd_params['transfer_fn'] = globals()[bwd_transfer_fn.decode()]
                 # construct the layer
-                bwd_layer = globals()['%sLayer' % bwd_type.decode()](
+                bwd_layer = globals()['{0!s}Layer'.format(bwd_type.decode())](
                     **bwd_params)
 
             # pop the parameters needed for the normal (forward) layer
@@ -558,7 +558,7 @@ class RecurrentNeuralNetwork(Processor):
             fwd_params = params
             fwd_params['transfer_fn'] = globals()[fwd_transfer_fn.decode()]
             # construct the layer
-            fwd_layer = globals()['%sLayer' % fwd_type.decode()](**fwd_params)
+            fwd_layer = globals()['{0!s}Layer'.format(fwd_type.decode())](**fwd_params)
 
             # return the (bidirectional) layer
             if bwd_layer is not None:
@@ -575,7 +575,7 @@ class RecurrentNeuralNetwork(Processor):
             # get all parameters for that layer
             layer_params = dict((k.split('_', 2)[2], data[k])
                                 for k in list(data.keys()) if
-                                k.startswith('layer_%d' % i))
+                                k.startswith('layer_{0:d}'.format(i)))
             # create a layer from these parameters
             layer = create_layer(layer_params)
             # add to the model

--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -598,7 +598,7 @@ def process_batch(processor, files, output_dir=None, output_suffix=None,
     for input_file in files:
         # set the output file name
         if output_dir is not None:
-            output_file = "%s/%s" % (output_dir, os.path.basename(input_file))
+            output_file = "{0!s}/{1!s}".format(output_dir, os.path.basename(input_file))
         else:
             output_file = input_file
         # strip off the extension

--- a/madmom/utils/__init__.py
+++ b/madmom/utils/__init__.py
@@ -89,13 +89,13 @@ def search_files(path, suffix=None):
     elif os.path.isdir(path):
         # use all files in the given path
         if suffix is None:
-            file_list = glob.glob("%s/*" % path)
+            file_list = glob.glob("{0!s}/*".format(path))
         elif isinstance(suffix, list):
             file_list = []
             for s in suffix:
-                file_list.extend(glob.glob("%s/*%s" % (path, s)))
+                file_list.extend(glob.glob("{0!s}/*{1!s}".format(path, s)))
         else:
-            file_list = glob.glob("%s/*%s" % (path, suffix))
+            file_list = glob.glob("{0!s}/*{1!s}".format(path, suffix))
     elif os.path.isfile(path):
         file_list = []
         # no matching needed
@@ -110,7 +110,7 @@ def search_files(path, suffix=None):
         elif path.endswith(suffix):
             file_list = [path]
     else:
-        raise IOError("%s does not exist." % path)
+        raise IOError("{0!s} does not exist.".format(path))
     # remove duplicates
     file_list = list(set(file_list))
     # sort files
@@ -170,9 +170,9 @@ def match_file(filename, match_list, suffix=None, match_suffix=None):
     matches = []
     # look for files with the same base name in the files_list
     if match_suffix is not None:
-        pattern = "*%s*%s" % (basename, match_suffix)
+        pattern = "*{0!s}*{1!s}".format(basename, match_suffix)
     else:
-        pattern = "*%s" % basename
+        pattern = "*{0!s}".format(basename)
     for match in fnmatch.filter(match_list, pattern):
         # base names must match exactly
         if basename == os.path.basename(strip_suffix(match, match_suffix)):

--- a/madmom/utils/midi.py
+++ b/madmom/utils/midi.py
@@ -76,18 +76,18 @@ for index in range(128):
     if len(note_name) == 2:
         # sharp note
         flat = NOTE_NAMES[note_idx + 1] + 'b'
-        NOTE_NAME_MAP_FLAT['%s_%d' % (flat, oct_idx)] = index
-        NOTE_NAME_MAP_SHARP['%s_%d' % (note_name, oct_idx)] = index
-        NOTE_VALUE_MAP_FLAT.append('%s_%d' % (flat, oct_idx))
-        NOTE_VALUE_MAP_SHARP.append('%s_%d' % (note_name, oct_idx))
-        globals()['%s_%d' % (note_name[0] + 's', oct_idx)] = index
-        globals()['%s_%d' % (flat, oct_idx)] = index
+        NOTE_NAME_MAP_FLAT['{0!s}_{1:d}'.format(flat, oct_idx)] = index
+        NOTE_NAME_MAP_SHARP['{0!s}_{1:d}'.format(note_name, oct_idx)] = index
+        NOTE_VALUE_MAP_FLAT.append('{0!s}_{1:d}'.format(flat, oct_idx))
+        NOTE_VALUE_MAP_SHARP.append('{0!s}_{1:d}'.format(note_name, oct_idx))
+        globals()['{0!s}_{1:d}'.format(note_name[0] + 's', oct_idx)] = index
+        globals()['{0!s}_{1:d}'.format(flat, oct_idx)] = index
     else:
-        NOTE_NAME_MAP_FLAT['%s_%d' % (note_name, oct_idx)] = index
-        NOTE_NAME_MAP_SHARP['%s_%d' % (note_name, oct_idx)] = index
-        NOTE_VALUE_MAP_FLAT.append('%s_%d' % (note_name, oct_idx))
-        NOTE_VALUE_MAP_SHARP.append('%s_%d' % (note_name, oct_idx))
-        globals()['%s_%d' % (note_name, oct_idx)] = index
+        NOTE_NAME_MAP_FLAT['{0!s}_{1:d}'.format(note_name, oct_idx)] = index
+        NOTE_NAME_MAP_SHARP['{0!s}_{1:d}'.format(note_name, oct_idx)] = index
+        NOTE_VALUE_MAP_FLAT.append('{0!s}_{1:d}'.format(note_name, oct_idx))
+        NOTE_VALUE_MAP_SHARP.append('{0!s}_{1:d}'.format(note_name, oct_idx))
+        globals()['{0!s}_{1:d}'.format(note_name, oct_idx)] = index
 
 BEAT_NAMES = ['whole', 'half', 'quarter', 'eighth', 'sixteenth',
               'thirty-second', 'sixty-fourth']
@@ -202,8 +202,8 @@ class EventRegistry(object):
         if any(b in (Event, NoteEvent) for b in event.__bases__):
             # raise an error if the event class is registered already
             if event.status_msg in cls.Events:
-                raise AssertionError("Event %s already registered" %
-                                     event.name)
+                raise AssertionError("Event {0!s} already registered".format(
+                                     event.name))
             # register the Event
             cls.Events[event.status_msg] = event
         # meta events
@@ -211,14 +211,14 @@ class EventRegistry(object):
             # raise an error if the meta event class is registered already
             if event.meta_command is not None:
                 if event.meta_command in EventRegistry.MetaEvents:
-                    raise AssertionError("Event %s already registered" %
-                                         event.name)
+                    raise AssertionError("Event {0!s} already registered".format(
+                                         event.name))
             # register the MetaEvent
             cls.MetaEvents[event.meta_command] = event
         else:
             # raise an error
-            raise ValueError("Unknown base class in event type: %s" %
-                             event.__bases__)
+            raise ValueError("Unknown base class in event type: {0!s}".format(
+                             event.__bases__))
 
 
 class AbstractEvent(object):
@@ -250,7 +250,7 @@ class AbstractEvent(object):
         return self.tick > other.tick
 
     def __str__(self):
-        return "%s: tick: %s data: %s" % (self.__class__.__name__, self.tick,
+        return "{0!s}: tick: {1!s} data: {2!s}".format(self.__class__.__name__, self.tick,
                                           self.data)
 
 # do not register AbstractEvent
@@ -278,7 +278,7 @@ class Event(AbstractEvent):
         return 0
 
     def __str__(self):
-        return "%s: tick: %s channel: %s" % (self.__class__.__name__,
+        return "{0!s}: tick: {1!s} channel: {2!s}".format(self.__class__.__name__,
                                              self.tick, self.channel)
 
     @classmethod
@@ -344,7 +344,7 @@ class MetaEventWithText(MetaEvent):
             self.text = ''.join(chr(datum) for datum in self.data)
 
     def __str__(self):
-        return "%s: %s" % (self.__class__.__name__, self.text)
+        return "{0!s}: {1!s}".format(self.__class__.__name__, self.text)
 
 # do not register MetaEventWithText
 
@@ -1130,7 +1130,7 @@ class MIDITrack(object):
             else:
                 raise ValueError("Unknown MIDI Event: " + str(event))
         # prepare the track header
-        track_header = b'MTrk%s' % struct.pack(">L", len(track_data))
+        track_header = b'MTrk{0!s}'.format(struct.pack(">L", len(track_data)))
         # return the track header + data
         return track_header + track_data
 
@@ -1156,7 +1156,7 @@ class MIDITrack(object):
         # first four bytes are Track header
         chunk = midi_stream.read(4)
         if chunk != b'MTrk':
-            raise TypeError("Bad track header in MIDI file: %s" % chunk)
+            raise TypeError("Bad track header in MIDI file: {0!s}".format(chunk))
         # next four bytes are track size
         track_size = struct.unpack(">L", midi_stream.read(4))[0]
         track_data = iter(midi_stream.read(track_size))
@@ -1172,7 +1172,7 @@ class MIDITrack(object):
                     cmd = next(track_data)
                     if cmd not in EventRegistry.MetaEvents:
                         import warnings
-                        warnings.warn("Unknown Meta MIDI Event: %s" % cmd)
+                        warnings.warn("Unknown Meta MIDI Event: {0!s}".format(cmd))
                         event_cls = UnknownMetaEvent
                     else:
                         event_cls = EventRegistry.MetaEvents[cmd]
@@ -1569,8 +1569,8 @@ class MIDIFile(object):
 
         """
         # generate a MIDI header
-        data = b'MThd%s' % struct.pack(">LHHH", 6, self.format,
-                                       len(self.tracks), self.resolution)
+        data = b'MThd{0!s}'.format(struct.pack(">LHHH", 6, self.format,
+                                       len(self.tracks), self.resolution))
         # append the tracks
         for track in self.tracks:
             data += track.data_stream
@@ -1661,7 +1661,7 @@ class MIDIFile(object):
                 track = MIDITrack.from_file(midi_file)
                 tracks.append(track)
         if resolution is None or midi_format is None:
-            raise IOError('unable to read MIDI file %s.' % midi_file)
+            raise IOError('unable to read MIDI file {0!s}.'.format(midi_file))
         # return a newly created object
         return cls(tracks=tracks, resolution=resolution,
                    file_format=midi_format)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:CPJKU:madmom?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:CPJKU:madmom?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)