### PR TITLE
remove pickling of data classes; fixes #79

### DIFF
--- a/madmom/audio/chroma.py
+++ b/madmom/audio/chroma.py
@@ -119,11 +119,15 @@ class PitchClassProfile(FilteredSpectrogram):
         # save additional attributes
         obj.filterbank = filterbank
         obj.spectrogram = spectrogram
-        # and those from the given spectrogram
-        obj.stft = spectrogram.stft
-        obj.frames = spectrogram.stft.frames
         # return the object
         return obj
+
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        # set default values here, also needed for views
+        self.filterbank = getattr(obj, 'filterbank', None)
+        self.spectrogram = getattr(obj, 'spectrogram', None)
 
 
 class HarmonicPitchClassProfile(PitchClassProfile):
@@ -202,8 +206,5 @@ class HarmonicPitchClassProfile(PitchClassProfile):
         # save additional attributes
         obj.filterbank = filterbank
         obj.spectrogram = spectrogram
-        # and those from the given spectrogram
-        obj.stft = spectrogram.stft
-        obj.frames = spectrogram.stft.frames
         # return the object
         return obj

--- a/madmom/audio/filters.py
+++ b/madmom/audio/filters.py
@@ -455,24 +455,6 @@ class Filter(np.ndarray):
         # return the object
         return obj
 
-    def __reduce__(self):
-        # needed for correct pickling
-        # source: http://stackoverflow.com/questions/26598109/
-        # get the parent's __reduce__ tuple
-        pickled_state = super(Filter, self).__reduce__()
-        # create our own tuple to pass to __setstate__
-        new_state = pickled_state[2] + (self.start, self.stop,)
-        # return a tuple that replaces the parent's __reduce__ tuple
-        return pickled_state[0], pickled_state[1], new_state
-
-    def __setstate__(self, state):
-        # needed for correct un-pickling
-        # set the start and stop bins
-        self.start = state[-2]
-        self.stop = state[-1]
-        # call the parent's __setstate__ with the other tuple elements
-        super(Filter, self).__setstate__(state[0:-2])
-
     @classmethod
     def band_bins(cls, bins, **kwargs):
         """
@@ -566,20 +548,6 @@ class TriangularFilter(Filter):
         obj.center = start + center
         # return the filter
         return obj
-
-    def __reduce__(self):
-        # get the parent's __reduce__ tuple
-        pickled_state = super(TriangularFilter, self).__reduce__()
-        # create our own tuple to pass to __setstate__
-        new_state = pickled_state[2] + (self.center,)
-        # return a tuple that replaces the parent's __reduce__ tuple
-        return pickled_state[0], pickled_state[1], new_state
-
-    def __setstate__(self, state):
-        # in addition to the start and stop bins, also set the center bin
-        self.center = state[-1]
-        # call the parent's __setstate__ with the other tuple elements
-        super(TriangularFilter, self).__setstate__(state[0:-1])
 
     @classmethod
     def band_bins(cls, bins, overlap=True):
@@ -768,20 +736,6 @@ class Filterbank(np.ndarray):
             return
         # set default values here
         self.bin_frequencies = getattr(obj, 'bin_frequencies', None)
-
-    def __reduce__(self):
-        # get the parent's __reduce__ tuple
-        pickled_state = super(Filterbank, self).__reduce__()
-        # create our own tuple to pass to __setstate__
-        new_state = pickled_state[2] + (self.bin_frequencies,)
-        # return a tuple that replaces the parent's __reduce__ tuple
-        return pickled_state[0], pickled_state[1], new_state
-
-    def __setstate__(self, state):
-        # set the bin frequencies
-        self.bin_frequencies = state[-1]
-        # call the parent's __setstate__ with the other tuple elements
-        super(Filterbank, self).__setstate__(state[0:-1])
 
     @classmethod
     def _put_filter(cls, filt, band):
@@ -1134,21 +1088,6 @@ class LogarithmicFilterbank(Filterbank):
                                             self.NUM_BANDS_PER_OCTAVE)
         self.fref = getattr(obj, 'fref', A4)
 
-    def __reduce__(self):
-        # get the parent's __reduce__ tuple
-        pickled_state = super(LogarithmicFilterbank, self).__reduce__()
-        # create our own tuple to pass to __setstate__
-        new_state = pickled_state[2] + (self.num_bands_per_octave, self.fref)
-        # return a tuple that replaces the parent's __reduce__ tuple
-        return pickled_state[0], pickled_state[1], new_state
-
-    def __setstate__(self, state):
-        # set the number of bands per octave and reference frequency
-        self.num_bands_per_octave = state[-2]
-        self.fref = state[-1]
-        # call the parent's __setstate__ with the other tuple elements
-        super(LogarithmicFilterbank, self).__setstate__(state[0:-2])
-
 
 # alias
 LogFilterbank = LogarithmicFilterbank
@@ -1212,20 +1151,6 @@ class RectangularFilterbank(Filterbank):
                                                      bin_frequencies)
         # return the object
         return obj
-
-    def __reduce__(self):
-        # get the parent's __reduce__ tuple
-        pickled_state = super(RectangularFilterbank, self).__reduce__()
-        # create our own tuple to pass to __setstate__
-        new_state = pickled_state[2] + (self.crossover_frequencies, )
-        # return a tuple that replaces the parent's __reduce__ tuple
-        return pickled_state[0], pickled_state[1], new_state
-
-    def __setstate__(self, state):
-        # set the additional attributes
-        self.crossover_frequencies = state[-1]
-        # call the parent's __setstate__ with the other tuple elements
-        super(RectangularFilterbank, self).__setstate__(state[0:-1])
 
 
 # chroma / harmonic filterbanks
@@ -1295,20 +1220,6 @@ class SimpleChromaFilterbank(Filterbank):
             return
         # set default values here
         self.fref = getattr(obj, 'fref', A4)
-
-    def __reduce__(self):
-        # get the parent's __reduce__ tuple
-        pickled_state = super(SimpleChromaFilterbank, self).__reduce__()
-        # create our own tuple to pass to __setstate__
-        new_state = pickled_state[2] + (self.fref,)
-        # return a tuple that replaces the parent's __reduce__ tuple
-        return pickled_state[0], pickled_state[1], new_state
-
-    def __setstate__(self, state):
-        # set the reference frequency
-        self.fref = state[-1]
-        # call the parent's __setstate__ with the other tuple elements
-        super(SimpleChromaFilterbank, self).__setstate__(state[0:-1])
 
 
 class HarmonicFilterbank(Filterbank):
@@ -1392,20 +1303,6 @@ class PitchClassProfileFilterbank(Filterbank):
             return
         # set default values here
         self.fref = getattr(obj, 'fref', A4)
-
-    def __reduce__(self):
-        # get the parent's __reduce__ tuple
-        pickled_state = super(PitchClassProfileFilterbank, self).__reduce__()
-        # create our own tuple to pass to __setstate__
-        new_state = pickled_state[2] + (self.fref,)
-        # return a tuple that replaces the parent's __reduce__ tuple
-        return pickled_state[0], pickled_state[1], new_state
-
-    def __setstate__(self, state):
-        # set the reference frequency
-        self.fref = state[-1]
-        # call the parent's __setstate__ with the other tuple elements
-        super(PitchClassProfileFilterbank, self).__setstate__(state[0:-1])
 
     @property
     def corner_frequencies(self):
@@ -1499,21 +1396,3 @@ class HarmonicPitchClassProfileFilterbank(PitchClassProfileFilterbank):
         # set default values here
         self.fref = getattr(obj, 'fref', A4)
         self.window = getattr(obj, 'window', self.WINDOW)
-
-    def __reduce__(self):
-        # get the parent's __reduce__ tuple
-        pickled_state = super(HarmonicPitchClassProfileFilterbank,
-                              self).__reduce__()
-        # create our own tuple to pass to __setstate__
-        # since we inherit from PitchClassProfileFilterbank, we don't need to
-        # care about fref
-        new_state = pickled_state[2] + (self.window, )
-        # return a tuple that replaces the parent's __reduce____ tuple
-        return pickled_state[0], pickled_state[1], new_state
-
-    def __setstate__(self, state):
-        # set the reference frequency
-        self.window = state[-1]
-        # call the parent's __setstate__ with the other tuple elements
-        super(HarmonicPitchClassProfileFilterbank,
-              self).__setstate__(state[0:-1])

--- a/madmom/audio/signal.py
+++ b/madmom/audio/signal.py
@@ -455,23 +455,6 @@ class Signal(np.ndarray):
         # set default values here, also needed for views of the Signal
         self.sample_rate = getattr(obj, 'sample_rate', None)
 
-    def __reduce__(self):
-        # needed for correct pickling
-        # source: http://stackoverflow.com/questions/26598109/
-        # get the parent's __reduce__ tuple
-        pickled_state = super(Signal, self).__reduce__()
-        # create our own tuple to pass to __setstate__
-        new_state = pickled_state[2] + (self.sample_rate,)
-        # return a tuple that replaces the parent's __reduce__ tuple
-        return pickled_state[0], pickled_state[1], new_state
-
-    def __setstate__(self, state):
-        # needed for correct un-pickling
-        # set the sample_rate
-        self.sample_rate = state[-1]
-        # call the parent's __setstate__ with the other tuple elements
-        super(Signal, self).__setstate__(state[0:-1])
-
     @property
     def num_samples(self):
         """Number of samples."""

--- a/madmom/features/__init__.py
+++ b/madmom/features/__init__.py
@@ -86,23 +86,6 @@ class Activations(np.ndarray):
         # set default values here
         self.fps = getattr(obj, 'fps', None)
 
-    def __reduce__(self):
-        # needed for correct pickling
-        # source: http://stackoverflow.com/questions/26598109/
-        # get the parent's __reduce__ tuple
-        pickled_state = super(Activations, self).__reduce__()
-        # create our own tuple to pass to __setstate__
-        new_state = pickled_state[2] + (self.fps,)
-        # return a tuple that replaces the parent's __reduce__ tuple
-        return pickled_state[0], pickled_state[1], new_state
-
-    def __setstate__(self, state):
-        # needed for correct un-pickling
-        # set the attributes
-        self.fps = state[-1]
-        # call the parent's __setstate__ with the other tuple elements
-        super(Activations, self).__setstate__(state[0:-1])
-
     @classmethod
     def load(cls, infile, fps=None, sep=None):
         """

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -557,17 +557,6 @@ class TestSignalClass(unittest.TestCase):
         self.assertTrue(result.ndim == 1)
         self.assertTrue(np.allclose(result.length, 2.8))
 
-    def test_pickling(self):
-        import pickle
-        import tempfile
-        result = Signal(AUDIO_PATH + '/sample.wav')
-        f, filename = tempfile.mkstemp()
-        pickle.dump(result, open(filename, 'wb'),
-                    protocol=pickle.HIGHEST_PROTOCOL)
-        result_ = pickle.load(open(filename, 'rb'))
-        self.assertTrue(np.allclose(result, result_))
-        self.assertTrue(result.sample_rate == result_.sample_rate)
-
 
 class TestSignalProcessorClass(unittest.TestCase):
 


### PR DESCRIPTION
Removed all the `__reduce__()` and `__setstate__()` methods which are needed for pickling of numpy arrays. Also refactored the `bin_frequencies` as an attribute instead of a property, since the old property had a if/else switch which was not really nice.

Having `bin_frequencies` as an attribute also helps to add the pickling stuff back in, since this is basically the information needed.