### PR TITLE
Use uint32_t for dtype=np.uint32 array

### DIFF
--- a/madmom/ml/hmm.pyx
+++ b/madmom/ml/hmm.pyx
@@ -20,6 +20,7 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
+from libc.stdint cimport uint32_t
 from libc.math cimport INFINITY
 
 
@@ -360,9 +361,9 @@ class HiddenMarkovModel(object):
         cdef double [::1] previous_viterbi = np.log(self.initial_distribution)
 
         # back-tracking pointers
-        cdef unsigned int [:, ::1] bt_pointers = np.empty((num_observations,
-                                                           num_states),
-                                                          dtype=np.uint32)
+        cdef uint32_t [:, ::1] bt_pointers = np.empty((num_observations,
+                                                       num_states),
+                                                      dtype=np.uint32)
         # define counters etc.
         cdef unsigned int state, frame, prev_state, pointer
         cdef double density, transition_prob


### PR DESCRIPTION
On my server (Ubuntu 14.04, Python 2.7.6, numpy 1.10.4, scipy 0.15.1, cython 0.23.4), running `DBNBeatTracker single tests/data/audio/sample.wav` with the latest code (commit c06b51ed0b3636f8262e98a26b6ac46f79cc9848 from develop) results in the following error:
```
Traceback (most recent call last):
  File "DBNBeatTracker", line 5, in <module>
    pkg_resources.run_script('madmom==0.13.dev', 'DBNBeatTracker')
  File "distribute-0.6.49-py2.7.egg/pkg_resources.py", line 507, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "distribute-0.6.49-py2.7.egg/pkg_resources.py", line 1272, in run_script
    execfile(script_filename, namespace, namespace)
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/EGG-INFO/scripts/DBNBeatTracker", line 149, in <module>
    main()
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/EGG-INFO/scripts/DBNBeatTracker", line 145, in main
    args.func(processor, **vars(args))
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/madmom/processors.py", line 514, in process_single
    processor(infile, outfile)
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/madmom/processors.py", line 109, in __call__
    return self.process(*args)
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/madmom/processors.py", line 496, in process
    return _process((self.out_processor, data, output))
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/madmom/processors.py", line 176, in _process
    return process_tuple[0](*process_tuple[1:])
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/madmom/processors.py", line 109, in __call__
    return self.process(*args)
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/madmom/processors.py", line 494, in process
    data = _process((self.in_processor, data, ))
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/madmom/processors.py", line 176, in _process
    return process_tuple[0](*process_tuple[1:])
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/madmom/processors.py", line 109, in __call__
    return self.process(*args)
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/madmom/processors.py", line 309, in process
    data = _process((processor, data))
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/madmom/processors.py", line 176, in _process
    return process_tuple[0](*process_tuple[1:])
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/madmom/processors.py", line 109, in __call__
    return self.process(*args)
  File "madmom-0.13.dev-py2.7-linux-x86_64.egg/madmom/features/beats.py", line 719, in process
    beat_range = self.om.pointers[path]
IndexError: index 166001704 is out of bounds for axis 0 with size 5617
```

It looks like this is because at https://github.com/craffel/madmom/blob/develop/madmom/ml/hmm.pyx#L363 `bt_pointers` is being declared as an `unsigned int`, which in my system appears to be interpreted as a 64-bit unsigned integer despite the `dtype=np.uint32` declaration, so there are issues when setting the value of `path` (with dtype `np.uint32`) to values from `bt_pointers`.  Using `uint32_t` from `libc.stdint` (this PR) is more explicit and prevents this error:
```
> DBNBeatTracker single tests/data/audio/sample.wav
0.090
0.800
1.480
2.150
```
I'm not sure if/where there are other places in the code where this would be an issue.  I couldn't find any in a cursory search, so this PR just addresses the one at https://github.com/craffel/madmom/blob/develop/madmom/ml/hmm.pyx#L363