### PR TITLE
WIP: add examples to docstrings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 before_script:
   - pep8 --ignore=E402 madmom tests bin
 script:
-  - nosetests --with-coverage
+  - nosetests --with-coverage --with-doctest
   # TODO: add executable programs
 after_success:
   - codecov

--- a/madmom/__init__.py
+++ b/madmom/__init__.py
@@ -15,6 +15,7 @@ Please see the README for further details of this package.
 
 from __future__ import absolute_import, division, print_function
 
+import numpy as np
 import pkg_resources
 
 # import all packages
@@ -25,3 +26,19 @@ __version__ = pkg_resources.get_distribution("madmom").version
 
 # keep namespace clean
 del pkg_resources
+
+
+# set and restore numpy's print options for doctests
+_NP_PRINT_OPTIONS = np.get_printoptions()
+
+
+def setup():
+    # pylint: disable=missing-docstring
+    # sets up the environment for doctests (when run through nose)
+    np.set_printoptions(precision=5, edgeitems=2, suppress=True)
+
+
+def teardown():
+    # pylint: disable=missing-docstring
+    # restore the environment after doctests (when run through nose)
+    np.set_printoptions(**_NP_PRINT_OPTIONS)

--- a/madmom/features/notes.py
+++ b/madmom/features/notes.py
@@ -210,6 +210,25 @@ class RNNPianoNoteProcessor(SequentialProcessor):
     """
     Processor to get a (piano) note activation function from a RNN.
 
+    Examples
+    --------
+    Create a RNNPianoNoteProcessor and pass a file through the processor to
+    obtain a note onset activation function (sampled with 100 frames per
+    second).
+
+    >>> proc = RNNPianoNoteProcessor()
+    >>> proc  # doctest: +ELLIPSIS
+    <madmom.features.notes.RNNPianoNoteProcessor object at 0x...>
+    >>> act = proc('tests/data/audio/sample.wav')
+    >>> act.shape
+    (281, 88)
+    >>> act  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    array([[-0.00014,  0.0002 , ..., -0.     ,  0.     ],
+           [ 0.00008,  0.0001 , ...,  0.00006, -0.00001],
+           ...,
+           [-0.00005, -0.00011, ...,  0.00005, -0.00001],
+           [-0.00017,  0.00002, ...,  0.00009, -0.00009]], dtype=float32)
+
     """
 
     def __init__(self, **kwargs):

--- a/madmom/features/onsets.py
+++ b/madmom/features/onsets.py
@@ -587,12 +587,6 @@ class SpectralOnsetProcessor(Processor):
         Onset detection function. See `METHODS` for possible values.
 
     """
-    FRAME_SIZE = 2048
-    FPS = 200
-    ONLINE = False
-    MAX_BINS = 3
-    TEMPORAL_FILTER = 0.015
-    TEMPORAL_ORIGIN = 0
 
     METHODS = ['superflux', 'complex_flux', 'high_frequency_content',
                'spectral_diff', 'spectral_flux', 'modified_kullback_leibler',
@@ -670,7 +664,7 @@ class RNNOnsetProcessor(SequentialProcessor):
     References
     ----------
     .. [1] "Universal Onset Detection with bidirectional Long Short-Term Memory
-            Neural Networks"
+           Neural Networks"
            Florian Eyben, Sebastian Böck, Björn Schuller and Alex Graves.
            Proceedings of the 11th International Society for Music Information
            Retrieval Conference (ISMIR), 2010.
@@ -678,6 +672,17 @@ class RNNOnsetProcessor(SequentialProcessor):
            Sebastian Böck, Andreas Arzt, Florian Krebs and Markus Schedl.
            Proceedings of the 15th International Conference on Digital Audio
            Effects (DAFx), 2012.
+
+    Examples
+    --------
+    Create a RNNOnsetProcessor and pass a file through the processor to obtain
+    an onset detection function (sampled with 100 frames per second).
+
+    >>> proc = RNNOnsetProcessor()
+    >>> proc  # doctest: +ELLIPSIS
+    <madmom.features.onsets.RNNOnsetProcessor object at 0x...>
+    >>> proc('tests/data/audio/sample.wav') # doctest: +ELLIPSIS
+    array([ 0.08313,  0.0024 ,  ...,  0.00205,  0.00527], dtype=float32)
 
     """
 
@@ -748,6 +753,17 @@ class CNNOnsetProcessor(SequentialProcessor):
     The implementation follows as closely as possible the original one, but
     part of the signal pre-processing differs in minor aspects, so results can
     differ slightly, too.
+
+    Examples
+    --------
+    Create a CNNOnsetProcessor and pass a file through the processor to obtain
+    an onset detection function (sampled with 100 frames per second).
+
+    >>> proc = CNNOnsetProcessor()
+    >>> proc  # doctest: +ELLIPSIS
+    <madmom.features.onsets.CNNOnsetProcessor object at 0x...>
+    >>> proc('tests/data/audio/sample.wav') # doctest: +ELLIPSIS
+    array([ 0.05369,  0.04205,  ...,  0.00024,  0.00014], dtype=float32)
 
     """
 
@@ -927,6 +943,22 @@ class PeakPickingProcessor(Processor):
            "Evaluating the Online Capabilities of Onset Detection Methods",
            Proceedings of the 13th International Society for Music Information
            Retrieval Conference (ISMIR), 2012.
+
+    Examples
+    --------
+    Create a PeakPickingProcessor. The returned array represents the positions
+    of the onsets in seconds, thus the expected sampling rate has to be given.
+
+    >>> proc = PeakPickingProcessor(fps=100)
+    >>> proc  # doctest: +ELLIPSIS
+    <madmom.features.onsets.PeakPickingProcessor object at 0x...>
+
+    Call this PeakPickingProcessor with the onset activation function obtained
+    by RNNOnsetProcessor to obtain the onset positions.
+
+    >>> act = RNNOnsetProcessor()('tests/data/audio/sample.wav')
+    >>> proc(act)  # doctest: +ELLIPSIS
+    array([ 0.09,  0.29,  0.45,  ...,  2.34,  2.49,  2.67])
 
     """
     FPS = 100

--- a/madmom/features/tempo.py
+++ b/madmom/features/tempo.py
@@ -256,6 +256,27 @@ class TempoEstimationProcessor(Processor):
     fps : float, optional
         Frames per second.
 
+    Examples
+    --------
+    Create a TempoEstimationProcessor. The returned array represents the
+    estimated tempi (given in beats per minute) and their relative strength.
+
+    >>> proc = TempoEstimationProcessor(fps=100)
+    >>> proc  # doctest: +ELLIPSIS
+    <madmom.features.tempo.TempoEstimationProcessor object at 0x...>
+
+    Call this TempoEstimationProcessor with the beat activation function
+    obtained by RNNBeatProcessor to estimate the tempi.
+
+    >>> from madmom.features.beats import RNNBeatProcessor
+    >>> act = RNNBeatProcessor()('tests/data/audio/sample.wav')
+    >>> proc(act)  # doctest: +NORMALIZE_WHITESPACE
+    array([[ 176.47059,  0.47469],
+           [ 117.64706,  0.17667],
+           [ 240.     ,  0.15371],
+           [  68.96552,  0.09864],
+           [  82.19178,  0.09629]])
+
     """
     # default values for tempo estimation
     METHOD = 'comb'

--- a/madmom/ml/gmm.py
+++ b/madmom/ml/gmm.py
@@ -4,7 +4,7 @@
 # pylint: disable=too-many-arguments
 """
 This module contains functionality needed for fitting and scoring Gaussian
-Mixture Models (GMMs) (needed e.g. in madmom.features.beats_hmm).
+Mixture Models (GMMs) (needed e.g. in madmom.features.beats).
 
 The needed functionality is taken from sklearn.mixture.GMM which is released
 under the BSD license and was written by these authors:
@@ -13,7 +13,7 @@ under the BSD license and was written by these authors:
 - Fabian Pedregosa <fabian.pedregosa@inria.fr>
 - Bertrand Thirion <bertrand.thirion@inria.fr>
 
-This version works with sklearn v0.16 an onwards.
+This version works with sklearn v0.16 (and hopefully onwards).
 All commits until 0650d5502e01e6b4245ce99729fc8e7a71aacff3 are incorporated.
 
 """
@@ -211,7 +211,6 @@ class GMM(object):
     Initializes parameters such that every mixture component has zero
     mean and identity covariance.
 
-
     Parameters
     ----------
     n_components : int, optional
@@ -237,6 +236,10 @@ class GMM(object):
 
     `converged_` : bool
         True when convergence was reached in fit(), False otherwise.
+
+    See Also
+    --------
+    sklearn.mixture.GMM
 
     """
 
@@ -270,7 +273,7 @@ class GMM(object):
 
         Returns
         -------
-        logprob : array_like, shape (n_samples,)
+        log_prob : array_like, shape (n_samples,)
             Log probabilities of each data point in `x`.
 
         responsibilities : array_like, shape (n_samples, n_components)
@@ -289,9 +292,9 @@ class GMM(object):
         lpr = (log_multivariate_normal_density(x, self.means_, self.covars_,
                                                self.covariance_type) +
                np.log(self.weights_))
-        logprob = logsumexp(lpr, axis=1)
-        responsibilities = np.exp(lpr - logprob[:, np.newaxis])
-        return logprob, responsibilities
+        log_prob = logsumexp(lpr, axis=1)
+        responsibilities = np.exp(lpr - log_prob[:, np.newaxis])
+        return log_prob, responsibilities
 
     def score(self, x):
         """
@@ -305,12 +308,12 @@ class GMM(object):
 
         Returns
         -------
-        logprob : array_like, shape (n_samples,)
+        log_prob : array_like, shape (n_samples,)
             Log probabilities of each data point in `x`.
 
         """
-        logprob, _ = self.score_samples(x)
-        return logprob
+        log_prob, _ = self.score_samples(x)
+        return log_prob
 
     def fit(self, x, random_state=None, tol=1e-3, min_covar=1e-3,
             n_iter=100, n_init=1, params='wmc', init_params='wmc'):

--- a/madmom/ml/nn/__init__.py
+++ b/madmom/ml/nn/__init__.py
@@ -51,6 +51,24 @@ class NeuralNetwork(Processor):
     layers : list
         Layers of the Neural Network.
 
+    Examples
+    --------
+    Create a NeuralNetwork from the given layers.
+
+    >>> from madmom.ml.nn.layers import FeedForwardLayer
+    >>> from madmom.ml.nn.activations import tanh, sigmoid
+    >>> l1_weights = [[0.5, -1., -0.3 , -0.2]]
+    >>> l1_bias = [0.05, 0., 0.8, -0.5]
+    >>> l1 = FeedForwardLayer(l1_weights, l1_bias, activation_fn=tanh)
+    >>> l2_weights = [-1, 0.9, -0.2 , 0.4]
+    >>> l2_bias = [0.5]
+    >>> l2 = FeedForwardLayer(l2_weights, l2_bias, activation_fn=sigmoid)
+    >>> nn = NeuralNetwork([l1, l2])
+    >>> nn  # doctest: +ELLIPSIS
+    <madmom.ml.nn.NeuralNetwork object at 0x...>
+    >>> nn(np.array([0, 0.5, 1, 0, 1, 2, 0]))  # doctest: +NORMALIZE_WHITESPACE
+    array([ 0.53305, 0.36903, 0.265 , 0.53305, 0.265 , 0.18612, 0.53305])
+
     """
 
     def __init__(self, layers):
@@ -58,7 +76,7 @@ class NeuralNetwork(Processor):
 
     def process(self, data):
         """
-        Process the given data with the RNN.
+        Process the given data with the neural network.
 
         Parameters
         ----------
@@ -102,6 +120,18 @@ class NeuralNetworkEnsemble(SequentialProcessor):
     -----
     If `ensemble_fn` is set to 'None', the predictions are returned as a list
     with the same length as the number of networks given.
+
+    Examples
+    --------
+    Create a NeuralNetworkEnsemble from the networks. Instead of supplying
+    the neural networks as parameter, they can also be loaded from file:
+
+    >>> from madmom.models import ONSETS_BRNN_PP
+    >>> nn = NeuralNetworkEnsemble.load(ONSETS_BRNN_PP)
+    >>> nn  # doctest: +ELLIPSIS
+    <madmom.ml.nn.NeuralNetworkEnsemble object at 0x...>
+    >>> nn(np.array([0, 0.5, 1, 0, 1, 2, 0]))  # doctest: +NORMALIZE_WHITESPACE
+    array([ 0.00116, 0.00213, 0.01428, 0.00729, 0.0088 , 0.21965, 0.00532])
 
     """
 

--- a/tests/test_audio_comb_filters.py
+++ b/tests/test_audio_comb_filters.py
@@ -61,6 +61,9 @@ class TestFeedBackwardFilterFunction(unittest.TestCase):
         result = feed_forward_comb_filter(sig_1d, 2, 0.5)
         self.assertIsInstance(result, np.ndarray)
         self.assertTrue(type(result), float)
+        result = feed_backward_comb_filter(sig_2d, 2, 0.5)
+        self.assertIsInstance(result, np.ndarray)
+        self.assertTrue(type(result), float)
 
     def test_values(self):
         result = feed_backward_comb_filter(sig_1d, 2, 0.5)
@@ -70,42 +73,6 @@ class TestFeedBackwardFilterFunction(unittest.TestCase):
         result = feed_backward_comb_filter(sig_2d, 2, 0.5)
         self.assertTrue(np.allclose(result, res_2d_bw_2))
         result = feed_backward_comb_filter(sig_2d, 3, 0.5)
-        self.assertTrue(np.allclose(result, res_2d_bw_3))
-
-
-class TestFeedBackwardFilter1DFunction(unittest.TestCase):
-
-    def test_types(self):
-        result = feed_backward_comb_filter_1d(sig_1d, 2, 0.5)
-        self.assertIsInstance(result, np.ndarray)
-        self.assertTrue(type(result), float)
-
-    def test_values(self):
-        with self.assertRaises(ValueError):
-            feed_backward_comb_filter_1d(sig_1d, 0, 0.5)
-        with self.assertRaises(ValueError):
-            feed_backward_comb_filter_1d(sig_2d, 0, 0.5)
-        result = feed_backward_comb_filter_1d(sig_1d, 2, 0.5)
-        self.assertTrue(np.allclose(result, res_1d_bw_2))
-        result = feed_backward_comb_filter_1d(sig_1d, 3, 0.5)
-        self.assertTrue(np.allclose(result, res_1d_bw_3))
-
-
-class TestFeedBackwardFilter2DFunction(unittest.TestCase):
-
-    def test_types(self):
-        result = feed_backward_comb_filter_2d(sig_2d, 2, 0.5)
-        self.assertIsInstance(result, np.ndarray)
-        self.assertTrue(type(result), float)
-
-    def test_values(self):
-        with self.assertRaises(ValueError):
-            feed_backward_comb_filter_2d(sig_2d, 0, 0.5)
-        with self.assertRaises(ValueError):
-            feed_backward_comb_filter_2d(sig_1d, 0, 0.5)
-        result = feed_backward_comb_filter_2d(sig_2d, 2, 0.5)
-        self.assertTrue(np.allclose(result, res_2d_bw_2))
-        result = feed_backward_comb_filter_2d(sig_2d, 3, 0.5)
         self.assertTrue(np.allclose(result, res_2d_bw_3))
 
 


### PR DESCRIPTION
Add docstring examples to all classes.

Audio

- [x] `madmom.audio.signal`
- [ ] `madmom.audio.filters`
- [x] `madmom.audio.comb_filters`
- [x] `madmom.audio.stft`
- [x] `madmom.audio.spectrogram`
- [ ] `madmom.audio.chroma` (@fdlm)
- [ ] ~~`madmom.audio.cepstrogram`~~ (will not be included in v.014)

Features

- [x] `madmom.features.beats`
- [ ] `madmom.features.chords` (@fdlm)
- [x] `madmom.features.notes`
- [x] `madmom.features.onsets`
- [x] `madmom.features.tempo`

Machine learning

- [x] `madmom.ml.nn`
- [x] `madmom.ml.gmm`
- [ ] `madmom.ml.crf` (@fdlm)
- [ ] `madmom.ml.hmm` (@fdlm)