### PR TITLE
Refactor neural networks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ API relevant changes:
 * Refactored the `ml.rnn` to `ml.nn` and converted the models to pickles (#110)
 * Reorderd the dimensions of comb_filters to time, freq, tau (#135)
 * `write_notes` uses `delimiter` instead of `sep` to seperate columns (#155)
+* `LSTMLayer` takes `Gate`s as arguments, all layers are callable (#161)
 
 Other changes:
 

--- a/madmom/ml/nn/__init__.py
+++ b/madmom/ml/nn/__init__.py
@@ -92,11 +92,23 @@ class NeuralNetworkEnsemble(SequentialProcessor):
     ----------
     networks : list
         List of the Neural Networks.
+    ensemble_fn : function or callable, optional
+        Ensemble function to be applied to the predictions of the neural
+        network ensemble (default: average predictions).
+    num_threads : int, optional
+        Number of parallel working threads.
+
+    Notes
+    -----
+    If `ensemble_fn` is set to 'None', the predictions are returned as a list
+    with the same length as the number of networks given.
 
     """
 
-    def __init__(self, networks, ensemble_fn=average_predictions):
-        networks_processor = ParallelProcessor(networks)
+    def __init__(self, networks, ensemble_fn=average_predictions,
+                 num_threads=None):
+        networks_processor = ParallelProcessor(networks,
+                                               num_threads=num_threads)
         super(NeuralNetworkEnsemble, self).__init__((networks_processor,
                                                      ensemble_fn))
 

--- a/madmom/ml/nn/__init__.py
+++ b/madmom/ml/nn/__init__.py
@@ -76,8 +76,8 @@ class NeuralNetwork(Processor):
             data = np.atleast_2d(data).T
         # loop over all layers
         for layer in self.layers:
-            # feed the output of one layer into the next one
-            data = layer.activate(data)
+            # activate the layer and feed the output into the next one
+            data = layer(data)
         # ravel the predictions if needed
         if data.ndim == 2 and data.shape[1] == 1:
             data = data.ravel()

--- a/madmom/ml/nn/layers.py
+++ b/madmom/ml/nn/layers.py
@@ -17,7 +17,35 @@ from .activations import tanh, sigmoid
 NN_DTYPE = np.float32
 
 
-class FeedForwardLayer(object):
+class Layer(object):
+    """
+    Generic callable network layer.
+
+    """
+
+    def __call__(self, *args):
+        # this magic method makes a Layer callable
+        return self.activate(*args)
+
+    def activate(self, data):
+        """
+        Activate the layer.
+
+        Parameters
+        ----------
+        data : numpy array
+            Activate with this data.
+
+        Returns
+        -------
+        numpy array
+            Activations for this data.
+
+        """
+        raise NotImplementedError('must be implemented by subclass.')
+
+
+class FeedForwardLayer(Layer):
     """
     Feed-forward network layer.
 
@@ -116,7 +144,7 @@ class RecurrentLayer(FeedForwardLayer):
         return out
 
 
-class BidirectionalLayer(object):
+class BidirectionalLayer(Layer):
     """
     Bidirectional network layer.
 
@@ -161,7 +189,7 @@ class BidirectionalLayer(object):
 
 
 # LSTM stuff
-class Cell(object):
+class Cell(Layer):
     """
     Cell as used by LSTM units.
 
@@ -252,7 +280,7 @@ class Gate(Cell):
         self.peephole_weights = peephole_weights.flatten()
 
 
-class LSTMLayer(object):
+class LSTMLayer(Layer):
     """
     Recurrent network layer with Long Short-Term Memory units.
 

--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -338,9 +338,7 @@ class ParallelProcessor(SequentialProcessor):
     """
     # pylint: disable=too-many-ancestors
 
-    NUM_THREADS = 1
-
-    def __init__(self, processors, num_threads=NUM_THREADS):
+    def __init__(self, processors, num_threads=None):
         # set the processing chain
         super(ParallelProcessor, self).__init__(processors)
         # number of threads
@@ -374,8 +372,8 @@ class ParallelProcessor(SequentialProcessor):
         # process data in parallel and return a list with processed data
         return list(self.map(_process, zip(self.processors, it.repeat(data))))
 
-    @classmethod
-    def add_arguments(cls, parser, num_threads=NUM_THREADS):
+    @staticmethod
+    def add_arguments(parser, num_threads):
         """
         Add parallel processing options to an existing parser object.
 
@@ -397,11 +395,6 @@ class ParallelProcessor(SequentialProcessor):
         Setting it smaller or equal to 0 sets it the number of CPU cores.
 
         """
-        if num_threads is None:
-            return None
-        # do not include the group
-        if num_threads <= 0:
-            num_threads = cls.NUM_THREADS
         # add parallel processing options
         g = parser.add_argument_group('parallel processing arguments')
         g.add_argument('-j', '--threads', dest='num_threads',

--- a/tests/test_ml_nn.py
+++ b/tests/test_ml_nn.py
@@ -58,7 +58,7 @@ class TestNeuralNetworkClass(unittest.TestCase):
     def test_blstm(self):
         rnn = NeuralNetwork.load(BEATS_BLSTM[0])
         input_size = rnn.layers[0].fwd_layer.cell.weights.shape[0]
-        data = np.zeros((4, input_size), dtype=np.float32)
+        data = np.zeros((4, input_size))
         data[1] = 1.
         result = rnn.process(data)
         self.assertTrue(np.allclose(result, [0.0815198, 0.24451593,


### PR DESCRIPTION
This PR makes `Layer`s callable, thus allowing to use simple functions as layers.
`Gate`s and `Cel`ls of `LSTMLayer` were refactored and the latter takes gates as arguments instead of combined weights.
Additionally, this PR fixes multi-threading of `NeuralNetworkEnsemble`.