### PR TITLE
load processors in binary and text mode

### DIFF
--- a/madmom/features/beats.py
+++ b/madmom/features/beats.py
@@ -1534,7 +1534,7 @@ SpectrogramDifferenceProcessor, MultiBandSpectrogramProcessor
         # pylint: disable=unused-argument
         # pylint: disable=no-name-in-module
 
-        import pickle
+        from madmom.utils import load_pickle_file
         from .beats_hmm import (BarStateSpace, BarTransitionModel,
                                 MultiPatternStateSpace,
                                 MultiPatternTransitionModel,
@@ -1568,15 +1568,7 @@ SpectrogramDifferenceProcessor, MultiBandSpectrogramProcessor
             raise ValueError('at least one rhythmical pattern must be given.')
         # load the patterns
         for p, pattern_file in enumerate(pattern_files):
-            with open(pattern_file, 'rb') as f:
-                # Python 2 and 3 behave differently
-                # TODO: use some other format to save the GMMs (.npz, .hdf5)
-                try:
-                    # Python 3
-                    pattern = pickle.load(f, encoding='latin1')
-                except TypeError:
-                    # Python 2 doesn't have/need the encoding
-                    pattern = pickle.load(f)
+            pattern = load_pickle_file(pattern_file)
             # get the fitted GMMs and number of beats
             gmms.append(pattern['gmms'])
             num_beats = pattern['num_beats']

--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -49,20 +49,8 @@ class Processor(object):
             Processor.
 
         """
-        import pickle
-        # close the open file if needed and use its name
-        if not isinstance(infile, str):
-            infile.close()
-            infile = infile.name
-        # instantiate a new Processor and return it
-        with open(infile, 'rb') as f:
-            # Python 2 and 3 behave differently
-            try:
-                # Python 3
-                obj = pickle.load(f, encoding='latin1')
-            except TypeError:
-                # Python 2 doesn't have/need the encoding
-                obj = pickle.load(f)
+        from madmom.utils import load_pickle_file
+        obj = load_pickle_file(infile)
         # warn if the unpickled Processor is of other type
         if obj.__class__ is not cls:
             import warnings

--- a/madmom/utils/__init__.py
+++ b/madmom/utils/__init__.py
@@ -578,6 +578,56 @@ def segment_axis(signal, frame_size, hop_size, axis=None, end='cut',
                                   dtype=signal.dtype)
 
 
+def load_pickle_file(infile):
+    """
+    Load a pickle file in both text and binary mode. Supports Python 2 and 3.
+
+    Parameters
+    ----------
+    infile : str or file handle
+            Pickle file.
+
+    Returns
+    -------
+    obj :
+        Unpickled object
+
+    Notes
+    -----
+    Loading files (that were pickled in text mode) in binary mode results in
+    an ImportError on Windows systems. On Unix systems this has not been
+    observed.
+
+    """
+    import pickle
+    # close the open file if needed and use its name
+    try:
+        infile.close()
+        infile = infile.name
+    except AttributeError:
+        pass
+    # open in binary mode
+    f = open(infile, 'rb')
+    # Python 2 and 3 behave differently
+    try:
+        # Python 3
+        obj = pickle.load(f, encoding='latin1')
+    except TypeError:
+        # Python 2 doesn't have/need the encoding
+        try:
+            obj = pickle.load(f)
+        except ImportError:
+            # open in text mode
+            f = open(infile, 'r')
+            obj = pickle.load(f)
+            pass
+    except ImportError:
+        # open in text mode
+        f = open(infile, 'r')
+        obj = pickle.load(f, encoding='latin1')
+    return obj
+
+
 # keep namespace clean
 del contextlib
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ This file contains test functions for the madmom.utils module.
 from __future__ import absolute_import, division, print_function
 
 import unittest
+import tempfile
 from os.path import join as pj
 
 from madmom.utils import *
@@ -84,6 +85,7 @@ ONSET_ANNOTATIONS = [0.0943, 0.2844, 0.4528, 0.6160, 0.7630, 0.8025, 0.9847,
                      2.6710]
 ONSET_DETECTIONS = [0.01, 0.085, 0.275, 0.445, 0.61, 0.795, 0.98, 1.115, 1.365,
                     1.475, 1.62, 1.795, 2.14, 2.33, 2.485, 2.665]
+tmp_file = tempfile.NamedTemporaryFile(delete=False).name
 
 
 class TestFilterFilesFunction(unittest.TestCase):
@@ -401,3 +403,31 @@ class TestSegmentAxisFunction(unittest.TestCase):
         result = segment_axis(np.arange(11), 4, 3, axis=0)
         self.assertTrue(np.allclose(result, [[0, 1, 2, 3], [3, 4, 5, 6],
                                              [6, 7, 8, 9]]))
+
+
+class TestLoadPickleFile(unittest.TestCase):
+
+    def setUp(self):
+        self.data = np.array([1, 2, 3, 4, 5])
+
+    def test_binary(self):
+        import pickle
+        # Note: for Python 2 / 3 compatibility reason use protocol 2
+        # save as binary
+        pickle.dump(self.data, open(tmp_file, 'wb'), protocol=2)
+        loaded = load_pickle_file(tmp_file)
+        self.assertTrue(np.allclose(self.data, loaded))
+
+    def test_text(self):
+        import pickle
+        # Note: for Python 2 / 3 compatibility reason use protocol 2
+        # save as text
+        pickle.dump(self.data, open(tmp_file, 'w'), protocol=2)
+        loaded = load_pickle_file(tmp_file)
+        self.assertTrue(np.allclose(self.data, loaded))
+
+
+# clean up
+def teardown():
+    import os
+    os.unlink(tmp_file)


### PR DESCRIPTION
Fixes issue [#7 of madmom_models](https://github.com/CPJKU/madmom_models/issues/7):
Processors that have been saved in text mode cannot be loaded in binary mode under Windows.
