### PR TITLE
[WIP] save previous output and state of RNNs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ Bug fixes:
 * Fix error loading unicode filenames (#223)
 * Fix ffmpeg unicode filename handling (#236)
 
+API relevant changes:
+
+* Reorder `GRUCell` parameters, to be consistent with all other layers (#235)
+
 Other changes:
 
 * `num_threads` is passed to `ParallelProcessor` in single mode (#217)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,11 +17,13 @@ Bug fixes:
 API relevant changes:
 
 * Reorder `GRUCell` parameters, to be consistent with all other layers (#235)
+* Rename `GRULayer` parameters, to be consistent with all other layers (#235)
 
 Other changes:
 
 * `num_threads` is passed to `ParallelProcessor` in single mode (#217)
 * Use `install_requires` in `setup.py` to specify dependencies (#226)
+* Allow initialisation of previous/hidden states in RNNs (#235)
 
 
 Version 0.14.1 (release date: 2016-08-01)

--- a/madmom/ml/nn/__init__.py
+++ b/madmom/ml/nn/__init__.py
@@ -71,8 +71,9 @@ class NeuralNetwork(Processor):
 
     """
 
-    def __init__(self, layers):
+    def __init__(self, layers, online=False):
         self.layers = layers
+        self.online = online
 
     def process(self, data):
         """
@@ -89,13 +90,16 @@ class NeuralNetwork(Processor):
             Network predictions for this data.
 
         """
+        # reset the layers? (online: do not reset, keep the state)
+        # Note: use getattr to be able to process old models
+        reset = not getattr(self, 'online', False)
         # check the dimensions of the data
         if data.ndim == 1:
             data = np.atleast_2d(data).T
         # loop over all layers
         for layer in self.layers:
             # activate the layer and feed the output into the next one
-            data = layer(data)
+            data = layer(data, reset=reset)
         # ravel the predictions if needed
         if data.ndim == 2 and data.shape[1] == 1:
             data = data.ravel()

--- a/madmom/ml/nn/layers.py
+++ b/madmom/ml/nn/layers.py
@@ -51,9 +51,9 @@ class FeedForwardLayer(Layer):
 
     Parameters
     ----------
-    weights : numpy array, shape ()
+    weights : numpy array, shape (num_inputs, num_hiddens)
         Weights.
-    bias : scalar or numpy array, shape ()
+    bias : scalar or numpy array, shape (num_hiddens,)
         Bias.
     activation_fn : numpy ufunc
         Activation function.
@@ -90,11 +90,11 @@ class RecurrentLayer(FeedForwardLayer):
 
     Parameters
     ----------
-    weights : numpy array, shape ()
+    weights : numpy array, shape (num_inputs, num_hiddens)
         Weights.
-    bias : scalar or numpy array, shape ()
+    bias : scalar or numpy array, shape (num_hiddens,)
         Bias.
-    recurrent_weights : numpy array, shape ()
+    recurrent_weights : numpy array, shape (num_hiddens, num_hiddens)
         Recurrent weights.
     activation_fn : numpy ufunc
         Activation function.
@@ -111,12 +111,12 @@ class RecurrentLayer(FeedForwardLayer):
 
         Parameters
         ----------
-        data : numpy array
+        data : numpy array, shape (num_frames, num_inputs)
             Activate with this data.
 
         Returns
         -------
-        numpy array
+        numpy array, shape (num_frames, num_hiddens)
             Activations for this data.
 
         """
@@ -163,12 +163,12 @@ class BidirectionalLayer(Layer):
 
         Parameters
         ----------
-        data : numpy array
+        data : numpy array, shape (num_frames, num_inputs)
             Activate with this data.
 
         Returns
         -------
-        numpy array
+        numpy array, shape (num_frames, num_hiddens)
             Activations for this data.
 
         """
@@ -187,13 +187,13 @@ class Gate(Layer):
 
     Parameters
     ----------
-    weights : numpy array, shape ()
+    weights : numpy array, shape (num_inputs, num_hiddens)
         Weights.
-    bias : scalar or numpy array, shape ()
+    bias : scalar or numpy array, shape (num_hiddens,)
         Bias.
-    recurrent_weights : numpy array, shape ()
+    recurrent_weights : numpy array, shape (num_hiddens, num_hiddens)
         Recurrent weights.
-    peephole_weights : numpy array, optional, shape ()
+    peephole_weights : numpy array, shape (num_hiddens,), optional
         Peephole weights.
     activation_fn : numpy ufunc, optional
         Activation function.
@@ -215,16 +215,16 @@ class Gate(Layer):
 
         Parameters
         ----------
-        data : scalar or numpy array, shape ()
+        data : scalar or numpy array, shape (num_hiddens,)
             Input data for the cell.
-        prev : scalar or numpy array, shape ()
+        prev : scalar or numpy array, shape (num_hiddens,)
             Output data of the previous time step.
-        state : scalar or numpy array, shape ()
+        state : scalar or numpy array, shape (num_hiddens,)
             State data of the {current | previous} time step.
 
         Returns
         -------
-        numpy array
+        numpy array, shape (num_hiddens,)
             Activations of the gate for this data.
 
         """
@@ -246,11 +246,11 @@ class Cell(Gate):
 
     Parameters
     ----------
-    weights : numpy array, shape ()
+    weights : numpy array, shape (num_inputs, num_hiddens)
         Weights.
-    bias : scalar or numpy array, shape ()
+    bias : scalar or numpy array, shape (num_hiddens,)
         Bias.
-    recurrent_weights : numpy array, shape ()
+    recurrent_weights : numpy array, shape (num_hiddens, num_hiddens)
         Recurrent weights.
     activation_fn : numpy ufunc, optional
         Activation function.
@@ -300,12 +300,12 @@ class LSTMLayer(Layer):
 
         Parameters
         ----------
-        data : numpy array
+        data : numpy array, shape (num_frames, num_inputs)
             Activate with this data.
 
         Returns
         -------
-        numpy array
+        numpy array, shape (num_frames, num_hiddens)
             Activations for this data.
 
         """
@@ -390,16 +390,16 @@ class GRUCell(object):
 
         Parameters
         ----------
-        data : numpy array, shape (, num_inputs)
+        data : numpy array, shape (num_inputs,)
             Input data for the cell.
         prev : numpy array, shape (num_hiddens,)
             Output of the previous time step.
-        reset_gate : scalar or numpy array, shape (num_hiddens,)
+        reset_gate : numpy array, shape (num_hiddens,)
             Activation of the reset gate.
 
         Returns
         -------
-        numpy array, shape (1, num_hiddens)
+        numpy array, shape (num_hiddens,)
             Activations of the cell for this data.
 
         """

--- a/madmom/ml/nn/layers.py
+++ b/madmom/ml/nn/layers.py
@@ -23,9 +23,9 @@ class Layer(object):
 
     """
 
-    def __call__(self, *args):
+    def __call__(self, *args, **kwargs):
         # this magic method makes a Layer callable
-        return self.activate(*args)
+        return self.activate(*args, **kwargs)
 
     def activate(self, data):
         """
@@ -65,7 +65,7 @@ class FeedForwardLayer(Layer):
         self.bias = bias
         self.activation_fn = activation_fn
 
-    def activate(self, data):
+    def activate(self, data, **kwargs):
         """
         Activate the layer.
 
@@ -180,7 +180,7 @@ class BidirectionalLayer(Layer):
         self.fwd_layer = fwd_layer
         self.bwd_layer = bwd_layer
 
-    def activate(self, data):
+    def activate(self, data, **kwargs):
         """
         Activate the layer.
 
@@ -200,9 +200,9 @@ class BidirectionalLayer(Layer):
 
         """
         # activate in forward direction
-        fwd = self.fwd_layer(data)
+        fwd = self.fwd_layer(data, **kwargs)
         # also activate with reverse input
-        bwd = self.bwd_layer(data[::-1])
+        bwd = self.bwd_layer(data[::-1], **kwargs)
         # stack data
         return np.hstack((fwd, bwd[::-1]))
 
@@ -700,7 +700,7 @@ class ConvolutionalLayer(FeedForwardLayer):
             raise NotImplementedError('only `pad` == "valid" implemented.')
         self.pad = pad
 
-    def activate(self, data):
+    def activate(self, data, **kwargs):
         """
         Activate the layer.
 
@@ -757,7 +757,7 @@ class StrideLayer(Layer):
     def __init__(self, block_size):
         self.block_size = block_size
 
-    def activate(self, data):
+    def activate(self, data, **kwargs):
         """
         Activate the layer.
 
@@ -798,7 +798,7 @@ class MaxPoolLayer(Layer):
             stride = size
         self.stride = stride
 
-    def activate(self, data):
+    def activate(self, data, **kwargs):
         """
         Activate the layer.
 
@@ -862,7 +862,7 @@ class BatchNormLayer(Layer):
         self.inv_std = inv_std
         self.activation_fn = activation_fn
 
-    def activate(self, data):
+    def activate(self, data, **kwargs):
         """
         Activate the layer.
 

--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -847,3 +847,4 @@ def io_arguments(parser, output_suffix='.txt', pickle=True, online=False):
         sp.set_defaults(origin='future')
         sp.set_defaults(num_frames=1)
         sp.set_defaults(stream=None)
+        sp.set_defaults(online=True)

--- a/tests/test_ml_nn.py
+++ b/tests/test_ml_nn.py
@@ -109,7 +109,7 @@ class TestGRUClass(unittest.TestCase):
             TestGRUClass.W_xu, TestGRUClass.b_u, TestGRUClass.W_hu,
             activation_fn=activations.sigmoid)
         self.gru_cell = layers.GRUCell(
-            TestGRUClass.W_xhu, TestGRUClass.W_hhu, TestGRUClass.b_hu)
+            TestGRUClass.W_xhu, TestGRUClass.b_hu, TestGRUClass.W_hhu)
         self.gru_1 = layers.GRULayer(self.reset_gate, self.update_gate,
                                      self.gru_cell)
         self.gru_2 = layers.GRULayer(self.reset_gate, self.update_gate,

--- a/tests/test_ml_nn.py
+++ b/tests/test_ml_nn.py
@@ -132,6 +132,19 @@ class TestRecurrentLayerClass(unittest.TestCase):
         result_2 = self.layer(self.data)
         self.assertTrue(np.allclose(result_1, result_2))
 
+    def test_activate_reset(self):
+        result_1 = self.layer(self.data)
+        # activate without resetting the layer
+        result_2 = self.layer.activate(self.data, reset=False)
+        self.assertFalse(np.allclose(result_1, result_2))
+        self.assertTrue(np.allclose(result_2[0, :2],
+                                    [-3.14807342e-01, -2.22700375e-01]))
+        self.assertTrue(np.allclose(result_2[-1, -2:],
+                                    [4.40259654e-01, -2.59141315e-01]))
+        self.assertTrue(np.allclose(self.layer._prev, result_2[-1]))
+        # initialisation must not change
+        self.assertTrue(np.allclose(self.layer.init, np.zeros(25)))
+
 
 class TestLSTMLayerClass(unittest.TestCase):
 
@@ -169,6 +182,21 @@ class TestLSTMLayerClass(unittest.TestCase):
         # two runs must yield identical results
         result_2 = self.layer(self.data)
         self.assertTrue(np.allclose(result_1, result_2))
+        # previous step must be last result
+        self.assertTrue(np.allclose(self.layer._prev, result_2[-1]))
+
+    def test_activate_reset(self):
+        result_1 = self.layer(self.data)
+        # activate without resetting the layer
+        result_2 = self.layer.activate(self.data, reset=False)
+        self.assertFalse(np.allclose(result_1, result_2))
+        self.assertTrue(np.allclose(result_2[0, :2],
+                                    [2.34878659e-01, -1.26488507e-03]))
+        self.assertTrue(np.allclose(result_2[-1, -2:],
+                                    [-2.45573238e-01, -2.92062219e-02]))
+        self.assertTrue(np.allclose(self.layer._prev, result_2[-1]))
+        # initialisation must not change
+        self.assertTrue(np.allclose(self.layer.init, np.zeros(25)))
 
 
 class TestGRUClass(unittest.TestCase):
@@ -197,6 +225,11 @@ class TestGRUClass(unittest.TestCase):
                    [-1.12282135, 0.3780883, 1.42017503],
                    [0.62669439, 0.89438929, -0.69354132],
                    [0.16162221, -1.00166208, 0.23579985]])
+    OUT = np.array([[0.22772433, -0.13181415],
+                    [0.49479958, 0.51224858],
+                    [0.08539771, -0.56119639],
+                    [0.1946809, -0.50421363],
+                    [0.17403202, -0.27258521]])
     H = np.array([0.02345737, 0.34454183])
 
     def setUp(self):
@@ -211,9 +244,9 @@ class TestGRUClass(unittest.TestCase):
         self.gru_1 = layers.GRULayer(self.reset_gate, self.update_gate,
                                      self.gru_cell)
         self.gru_2 = layers.GRULayer(self.reset_gate, self.update_gate,
-                                     self.gru_cell, hid_init=TestGRUClass.H)
+                                     self.gru_cell, init=TestGRUClass.H)
 
-    def test_process(self):
+    def test_activate(self):
         self.assertTrue(
             np.allclose(self.reset_gate.activate(TestGRUClass.IN[0, :],
                         TestGRUClass.H), np.array([0.20419282, 0.08861294])))
@@ -224,13 +257,13 @@ class TestGRUClass(unittest.TestCase):
             np.allclose(self.gru_cell.activate(TestGRUClass.IN[0, :],
                         TestGRUClass.H, TestGRUClass.H),
                         np.array([0.9366396, -0.67876764])))
-        self.assertTrue(
-            np.allclose(self.gru_1.activate(TestGRUClass.IN),
-                        np.array([[0.22772433, -0.13181415],
-                                  [0.49479958, 0.51224858],
-                                  [0.08539771, -0.56119639],
-                                  [0.1946809, -0.50421363],
-                                  [0.17403202, -0.27258521]])))
+        # activation of the layer
+        self.assertTrue(np.allclose(self.gru_1.activate(TestGRUClass.IN),
+                                    TestGRUClass.OUT))
+        # activating the layer a second time must give the same results
+        self.assertTrue(np.allclose(self.gru_1.activate(TestGRUClass.IN),
+                                    TestGRUClass.OUT))
+        # activating the other layer
         self.assertTrue(
             np.allclose(self.gru_2.activate(TestGRUClass.IN),
                         np.array([[0.30988133, 0.13258138],
@@ -238,6 +271,24 @@ class TestGRUClass(unittest.TestCase):
                                   [0.21366976, -0.55568963],
                                   [0.30860096, -0.43686554],
                                   [0.28866628, -0.23025239]])))
+
+    def test_activate_reset(self):
+        # first activate the layer normally
+        self.assertTrue(np.allclose(self.gru_1.activate(TestGRUClass.IN),
+                                    TestGRUClass.OUT))
+        # then again, but reset it first
+        self.assertTrue(np.allclose(self.gru_1.activate(TestGRUClass.IN,
+                                                        reset=False),
+                                    np.array([[0.3254016, -0.33195618],
+                                              [0.53048187, 0.51293057],
+                                              [0.12495148, -0.559039],
+                                              [0.22988503, -0.48455557],
+                                              [0.20934506, -0.25959042]])))
+        # the previous state must be the last output
+        self.assertTrue(np.allclose(self.gru_1._prev,
+                                    [0.20934506, -0.25959042]))
+        # initialisation must not change
+        self.assertTrue(np.allclose(self.gru_1.init, [0, 0]))
 
 
 class TestBatchNormLayerClass(unittest.TestCase):


### PR DESCRIPTION
This change enables recurrent neural networks to be initialised with an initial output/state (#230), to be streaming compatible (#185), and also fixes some GRU related parameter glitches (#234).

Unfortunately, this change breaks the API, since parameters are reordered and renamed.
Any thoughts?