### PR TITLE
Stateful processing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Bug fixes:
 
 API relevant changes:
 
+* `NeuralNetwork` expect 2D inputs; activation can be computed stepwise (#244)
 * Reorder `GRUCell` parameters, to be consistent with all other layers (#243)
 * Rename `GRULayer` parameters, to be consistent with all other layers (#243)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Other changes:
 * `num_threads` is passed to `ParallelProcessor` in single mode (#217)
 * Use `install_requires` in `setup.py` to specify dependencies (#226)
 * Allow initialisation of previous/hidden states in RNNs (#243)
+* Forward path of `HMM` can be computed stepwise (#244)
 
 
 Version 0.14.1 (release date: 2016-08-01)

--- a/bin/SuperFluxNN
+++ b/bin/SuperFluxNN
@@ -8,6 +8,7 @@ SuperFlux with neural network based peak picking onset detection algorithm.
 from __future__ import absolute_import, division, print_function
 
 import argparse
+import numpy as np
 
 from madmom.processors import IOProcessor, io_arguments
 from madmom.audio.signal import SignalProcessor, FramedSignalProcessor
@@ -103,7 +104,9 @@ def main():
         pp = PeakPickingProcessor(**vars(args))
         from madmom.utils import write_events as writer
         # sequentially process them
-        out_processor = [rnn, pp, writer]
+        # Note: we need np.atleast_2d and np.transpose before the RNN, since
+        #       it expects the data in 2D (1D means framewise processing)
+        out_processor = [np.atleast_2d, np.transpose, rnn, pp, writer]
 
     # create an IOProcessor
     processor = IOProcessor(in_processor, out_processor)

--- a/tests/test_ml_hmm.py
+++ b/tests/test_ml_hmm.py
@@ -127,8 +127,23 @@ class TestHiddenMarkovModelClass(unittest.TestCase):
     def test_forward(self):
         fwd = self.hmm.forward(OBS_SEQ)
         self.assertTrue(np.allclose(fwd, CORRECT_FWD))
+        # two runs must yield identical results
+        fwd = self.hmm.forward(OBS_SEQ)
+        self.assertTrue(np.allclose(fwd, CORRECT_FWD))
+        # after resetting the HMM, it must produce the same output as before
+        self.hmm.reset()
+        fwd = np.vstack([self.hmm.forward(o, reset=False) for o in OBS_SEQ])
+        self.assertTrue(np.allclose(fwd, CORRECT_FWD))
+        # without resetting it produces different results
+        fwd = np.vstack([self.hmm.forward(o, reset=False) for o in OBS_SEQ])
+        self.assertFalse(np.allclose(fwd, CORRECT_FWD))
+        # after resetting it must yield the correct result again
+        self.hmm.reset()
+        fwd = np.vstack([self.hmm.forward(o, reset=False) for o in OBS_SEQ])
+        self.assertTrue(np.allclose(fwd, CORRECT_FWD))
+        # initialisation must not change
+        self.assertTrue(np.allclose(self.hmm.initial_distribution, PRIOR))
 
     def test_forward_generator(self):
-        fwd = np.vstack(list(self.hmm.forward_generator(OBS_SEQ,
-                                                        block_size=5)))
+        fwd = np.vstack(self.hmm.forward_generator(OBS_SEQ, block_size=5))
         self.assertTrue(np.allclose(fwd, CORRECT_FWD))


### PR DESCRIPTION
This PR adds proper stateful processing.

The `process()` method of stateful processors accepts an additional/new `reset` argument, which defaults to `True` and thus does not change existing behaviour. This is implemented for `HMMs` and `RNNs`.

To be able to process sequences either as a whole or on a frame-by-frame basis, `process()` expects always the same data dimensionality. `NeuralNetwork` previously corrected the dimensions if a 1-dimensional input feature is expected (e.g. `SuperFluxNN`). This conversion is moved to the executable program instead.

If data is processed framewise, `reset=False` must be passed to the processors, otherwise stateful processors get reseted constantly. To be able to pass additional keyword arguments, `madmom.processors` was adapted accordingly.
