### PR TITLE
Fixed num_states property in TransitionModel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Release Notes
 Version 0.16.dev0
 -----------------
 
+Bug fixes:
+
+* Fix `TransitionModel` not returning the correct number of states (#284)
+
 Other changes:
 
 * Viterbi decoding of `HMM` raises a warning if no valid path is found (#279)

--- a/madmom/ml/hmm.pyx
+++ b/madmom/ml/hmm.pyx
@@ -82,11 +82,12 @@ class TransitionModel(object):
         self.states = states
         self.pointers = pointers
         self.probabilities = probabilities
+        self._num_states = int(states.max() + 1)
 
     @property
     def num_states(self):
         """Number of states."""
-        return len(self.pointers) - 1
+        return self._num_states
 
     @property
     def num_transitions(self):

--- a/tests/test_ml_hmm.py
+++ b/tests/test_ml_hmm.py
@@ -85,6 +85,12 @@ class TestTransitionModelClass(unittest.TestCase):
         self.assertTrue(self.tm.num_states == 3)
         self.assertTrue(self.tm.num_transitions == 7)
 
+    def test_unreachable_state(self):
+        A = np.array([[1., 0.], [1., 0.]])
+        frm, to = A.nonzero()
+        tm = TransitionModel.from_dense(to, frm, A[frm, to])
+        self.assertTrue(tm.num_states == 2)
+
 
 class TestDiscreteObservationModelClass(unittest.TestCase):
 


### PR DESCRIPTION
It should now report the correct number of states, even if some of them are unreachable. Addresses #283.

However, accessing `num_states` now takes longer than before. Should we cache this value?