### PR TITLE
Fix encoding error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ requirements = ['numpy>=1.8.1',
                 ]
 
 # docs to be included
-long_description = open('README.rst').read()
-long_description += '\n' + open('CHANGES.rst').read()
+long_description = open('README.rst', encoding='utf-8').read()
+long_description += '\n' + open('CHANGES.rst', encoding='utf-8').read()
 
 # the actual setup routine
 setup(name='madmom',


### PR DESCRIPTION
I got following error on Ubuntu 16.04:

```sh
$ pip install madmom
Collecting madmom
  Using cached madmom-0.15.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-bg4utrgn/madmom/setup.py", line 68, in <module>
        long_description = open('README.rst').read()
      File "/home/junkim/anaconda3/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 8643: ordinal not in range(128)

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-bg4utrgn/madmom/
```

It worked well on my Mac, but crashed on Ubuntu.

Anyway, I could fix the error with this patch.