### PR TITLE
online TempoEstimationProcessor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Bug fixes:
 
 API relevant changes:
 
+* `BufferProcessor` uses `data` instead of `buffer` for data storage (#292)
 * `DBNBeatTrackingProcessor` expects 1D inputs (#299)
 * Moved downbeat and pattern tracking to `features.downbeats` (#316)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 0.16.dev0
 
 New features:
 
+* `TempoDetector` can operate on live audio signals  (#292)
 * Added chord evaluation (#309)
 * Bar tracking functionality (#316)
 * Added `quantize_notes` function (#327)

--- a/bin/TempoDetector
+++ b/bin/TempoDetector
@@ -50,7 +50,7 @@ def main():
     # version
     p.add_argument('--version', action='version', version='TempoDetector.2016')
     # input/output options
-    io_arguments(p, output_suffix='.bpm.txt')
+    io_arguments(p, output_suffix='.bpm.txt', online=True)
     ActivationsProcessor.add_arguments(p)
     # signal processing arguments
     SignalProcessor.add_arguments(p, norm=False, gain=0)

--- a/bin/TempoDetector
+++ b/bin/TempoDetector
@@ -55,7 +55,10 @@ def main():
     # signal processing arguments
     SignalProcessor.add_arguments(p, norm=False, gain=0)
     # tempo arguments
-    TempoEstimationProcessor.add_arguments(p)
+    TempoEstimationProcessor.add_arguments(p, method='comb', min_bpm=40.,
+                                           max_bpm=250., act_smooth=0.14,
+                                           hist_smooth=9, hist_buffer=10.,
+                                           alpha=0.79)
     # mirex stuff
     g = p.add_mutually_exclusive_group()
     g.add_argument('--mirex', dest='tempo_format',

--- a/madmom/features/beats.py
+++ b/madmom/features/beats.py
@@ -337,8 +337,15 @@ class BeatTrackingProcessor(Processor):
     look_ahead : float, optional
         Look `look_ahead` seconds in both directions to determine the local
         tempo and align the beats accordingly.
+    tempo_estimator : :class:`TempoEstimationProcessor`, optional
+        Use this processor to estimate the (local) tempo. If 'None' a default
+        tempo estimator will be created and used.
     fps : float, optional
         Frames per second.
+    kwargs : dict, optional
+        Keyword arguments passed to
+        :class:`madmom.features.tempo.TempoEstimationProcessor` if no
+        `tempo_estimator` was given.
 
     Notes
     -----
@@ -382,25 +389,21 @@ class BeatTrackingProcessor(Processor):
 
     """
     LOOK_ASIDE = 0.2
-    LOOK_AHEAD = 10
-    # tempo defaults
-    TEMPO_METHOD = 'comb'
-    MIN_BPM = 40
-    MAX_BPM = 240
-    ACT_SMOOTH = 0.09
-    HIST_SMOOTH = 7
-    ALPHA = 0.79
+    LOOK_AHEAD = 10.
 
     def __init__(self, look_aside=LOOK_ASIDE, look_ahead=LOOK_AHEAD, fps=None,
-                 **kwargs):
-        # import the TempoEstimation here otherwise we have a loop
-        from .tempo import TempoEstimationProcessor
+                 tempo_estimator=None, **kwargs):
         # save variables
         self.look_aside = look_aside
         self.look_ahead = look_ahead
         self.fps = fps
         # tempo estimator
-        self.tempo_estimator = TempoEstimationProcessor(fps=fps, **kwargs)
+        if tempo_estimator is None:
+            # import the TempoEstimation here otherwise we have a loop
+            from .tempo import TempoEstimationProcessor
+            # create default tempo estimator
+            tempo_estimator = TempoEstimationProcessor(fps=fps, **kwargs)
+        self.tempo_estimator = tempo_estimator
 
     def process(self, activations, **kwargs):
         """

--- a/madmom/features/beats.py
+++ b/madmom/features/beats.py
@@ -15,7 +15,8 @@ import numpy as np
 
 from ..audio.signal import smooth as smooth_signal
 from ..ml.nn import average_predictions
-from ..processors import ParallelProcessor, Processor, SequentialProcessor
+from ..processors import (OnlineProcessor, ParallelProcessor, Processor,
+                          SequentialProcessor)
 
 
 # classes for tracking (down-)beats with RNNs
@@ -792,7 +793,7 @@ class CRFBeatDetectionProcessor(BeatTrackingProcessor):
         return g
 
 
-class DBNBeatTrackingProcessor(Processor):
+class DBNBeatTrackingProcessor(OnlineProcessor):
     """
     Beat tracking with RNNs and a dynamic Bayesian network (DBN) approximated
     by a Hidden Markov Model (HMM).
@@ -913,27 +914,7 @@ class DBNBeatTrackingProcessor(Processor):
         self.last_beat = 0
         self.tempo = 0
 
-    def process(self, activations, **kwargs):
-        """
-        Detect the beats in the given activation function.
-
-        Parameters
-        ----------
-        activations : numpy array
-            Beat activation function.
-
-        Returns
-        -------
-        beats : numpy array
-            Detected beat positions [seconds].
-
-        """
-        if self.online:
-            return self.process_forward(activations, **kwargs)
-        else:
-            return self.process_viterbi(activations, **kwargs)
-
-    def process_viterbi(self, activations, **kwargs):
+    def process_offline(self, activations, **kwargs):
         """
         Detect the beats in the given activation function with Viterbi
         decoding.
@@ -998,7 +979,7 @@ class DBNBeatTrackingProcessor(Processor):
         # convert the detected beats to seconds and return them
         return (beats + first) / float(self.fps)
 
-    def process_forward(self, activations, reset=True, **kwargs):
+    def process_online(self, activations, reset=True, **kwargs):
         """
         Detect the beats in the given activation function with the forward
         algorithm.
@@ -1055,7 +1036,7 @@ class DBNBeatTrackingProcessor(Processor):
             sys.stderr.write('\r%s' % ''.join(display))
             sys.stderr.flush()
         # forward path often reports multiple beats close together, thus report
-        # only beats more than the minumum interval apart
+        # only beats more than the minimum interval apart
         beats_ = []
         for frame in np.nonzero(beats)[0]:
             cur_beat = (frame + self.counter) / float(self.fps)
@@ -1073,6 +1054,10 @@ class DBNBeatTrackingProcessor(Processor):
         self.counter += len(activations)
         # return beat(s)
         return np.array(beats_)
+
+    process_forward = process_online
+
+    process_viterbi = process_offline
 
     @staticmethod
     def add_arguments(parser, min_bpm=MIN_BPM, max_bpm=MAX_BPM,

--- a/madmom/features/beats_hmm.py
+++ b/madmom/features/beats_hmm.py
@@ -80,17 +80,17 @@ class BeatStateSpace(object):
                 intervals = np.unique(np.round(intervals))
                 num_log_intervals += 1
         # save the intervals
-        self.intervals = np.ascontiguousarray(intervals, dtype=np.uint32)
+        self.intervals = np.ascontiguousarray(intervals, dtype=np.int)
         # number of states and intervals
         self.num_states = int(np.sum(intervals))
         self.num_intervals = len(intervals)
         # define first and last states
         first_states = np.cumsum(np.r_[0, self.intervals[:-1]])
-        self.first_states = first_states.astype(np.uint32)
-        self.last_states = np.cumsum(self.intervals).astype(np.uint32) - 1
+        self.first_states = first_states.astype(np.int)
+        self.last_states = np.cumsum(self.intervals) - 1
         # define the positions and intervals of the states
         self.state_positions = np.empty(self.num_states)
-        self.state_intervals = np.empty(self.num_states, dtype=np.uint32)
+        self.state_intervals = np.empty(self.num_states, dtype=np.int)
         # Note: having an index counter is faster than ndenumerate
         idx = 0
         for i in self.intervals:
@@ -150,7 +150,7 @@ class BarStateSpace(object):
         # model N beats as a bar
         self.num_beats = int(num_beats)
         self.state_positions = np.empty(0)
-        self.state_intervals = np.empty(0, dtype=np.uint32)
+        self.state_intervals = np.empty(0, dtype=np.int)
         self.num_states = 0
         # save the first and last states of the individual beats in a list
         self.first_states = []
@@ -196,8 +196,8 @@ class MultiPatternStateSpace(object):
         self.num_patterns = len(state_spaces)
         self.state_spaces = state_spaces
         self.state_positions = np.empty(0)
-        self.state_intervals = np.empty(0, dtype=np.uint32)
-        self.state_patterns = np.empty(0, dtype=np.uint32)
+        self.state_intervals = np.empty(0, dtype=np.int)
+        self.state_patterns = np.empty(0, dtype=np.int)
         self.num_states = 0
         # save the first and last states of the individual patterns in a list
         self.first_states = []

--- a/madmom/features/tempo.py
+++ b/madmom/features/tempo.py
@@ -215,7 +215,7 @@ def detect_tempo(histogram, fps):
     if len(peaks) == 0:
         # a flat histogram has no peaks, use the center bin
         if len(bins):
-            ret = np.asarray([tempi[len(bins) / 2], 1.])
+            ret = np.asarray([tempi[len(bins) // 2], 1.])
         else:
             # otherwise: no peaks, no tempo
             ret = np.asarray([NO_TEMPO, 0.])

--- a/madmom/features/tempo.py
+++ b/madmom/features/tempo.py
@@ -373,6 +373,8 @@ class CombFilterTempoHistogramProcessor(TempoHistogramProcessor):
         # reset to initial state
         if reset:
             self.reset()
+        if activations.size != 1:
+            raise NotImplementedError('can only be called frame by frame')
         # expand the activation for every tau
         activations = np.full(len(self.intervals), activations, dtype=np.float)
         # append it to the comb filter matrix
@@ -474,6 +476,8 @@ class ACFTempoHistogramProcessor(TempoHistogramProcessor):
         # reset to initial state
         if reset:
             self.reset()
+        if activations.size != 1:
+            raise NotImplementedError('can only be called frame by frame')
         # select relevant activations from buffer for subtraction
         buf = self.buffer.buffer[self.min_interval:self.max_interval + 1]
         # subtract oldest acf values before activations are removed from buffer

--- a/madmom/features/tempo.py
+++ b/madmom/features/tempo.py
@@ -379,7 +379,7 @@ class CombFilterTempoHistogramProcessor(TempoHistogramProcessor):
         # indices at which to retrieve y[n - τ]
         idx = [-self.intervals, np.arange(len(self.intervals))]
         # online feed backward comb filter (y[n] = x[n] + α * y[n - τ])
-        y_n = activations + self.alpha * self._comb_buffer.buffer[idx]
+        y_n = activations + self.alpha * self._comb_buffer[idx]
         # shift output buffer with new value
         self._comb_buffer(y_n)
         # determine the tau with the highest value
@@ -475,10 +475,10 @@ class ACFTempoHistogramProcessor(TempoHistogramProcessor):
         if activations.size != 1:
             raise NotImplementedError('can only be called frame by frame')
         # select relevant activations from buffer for subtraction
-        buf = self.buffer.buffer[self.min_interval:self.max_interval + 1]
+        buf = self.buffer[self.min_interval:self.max_interval + 1]
         # subtract oldest acf values before activations are removed from buffer
         # as long as the buffer is not filled this will subtract 0
-        self.bins -= buf * self.buffer.buffer[0]
+        self.bins -= buf * self.buffer[0]
         # shift buffer and put new activation at end of buffer
         buf = self.buffer(activations)
         # select relevant activations from buffer for addition

--- a/madmom/features/tempo.py
+++ b/madmom/features/tempo.py
@@ -783,7 +783,17 @@ class TempoEstimationProcessor(Processor):
             tempi.append(tempo)
             # visualize tempo
             if self.visualize:
-                sys.stderr.write('\r%s' % ''.join(str(tempo[:2, 0])))
+                display = ''
+                # display the 3 most likely tempi and their strengths
+                for i, display_tempo in enumerate(tempo[:3], start=1):
+                    # display tempo
+                    display += '| ' + str(round(display_tempo[0], 1)) + ' '
+                    # display strength
+                    display += min(int(display_tempo[1] * 50), 18) * '*'
+                    # fill up the rest with spaces
+                    display = display.ljust(i * 26)
+                # print the tempi
+                sys.stderr.write('\r%s' % ''.join(display) + '|')
                 sys.stderr.flush()
         # return last detected tempo
         return tempi[-1]

--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -639,11 +639,16 @@ class BufferProcessor(Processor):
     ----------
     buffer_size : int or tuple
         Size of the buffer (time steps, [additional dimensions]).
+    init : numpy array, optional
+        Init the buffer with this array.
+    init_value : float, optional
+        If only `buffer_size` is given but no `init`, use this value to
+        initialise the buffer.
 
     Notes
     -----
-    If `buffer_size` (or the first value thereof) is 1, only the un-buffered
-    current value is returned.
+    If `buffer_size` (or the first item thereof in case of tuple) is 1,
+    only the un-buffered current value is returned.
 
     If context is needed, `buffer_size` must be set to >1.
     E.g. SpectrogramDifference needs a context of two frames to be able to
@@ -664,7 +669,20 @@ class BufferProcessor(Processor):
             init = np.ones(buffer_size) * init_value
         # save variables
         self.buffer_size = buffer_size
+        self.init = init
         self.buffer = init
+
+    def reset(self, init=None):
+        """
+        Reset BufferProcessor to its initial state.
+
+        Parameters
+        ----------
+        init : numpy array, shape (num_hiddens,), optional
+            Reset BufferProcessor to this initial state.
+
+        """
+        self.buffer = init if init is not None else self.init
 
     def process(self, data, **kwargs):
         """

--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -15,15 +15,14 @@ objects can be chained/combined to achieve the wanted functionality.
 
 from __future__ import absolute_import, division, print_function
 
-import os
-import sys
 import argparse
 import itertools as it
 import multiprocessing as mp
+import os
+import sys
+from collections import MutableSequence
 
 import numpy as np
-
-from collections import MutableSequence
 
 
 class Processor(object):
@@ -121,11 +120,108 @@ class Processor(object):
             Processed data.
 
         """
-        raise NotImplementedError('must be implemented by subclass.')
+        raise NotImplementedError('Must be implemented by subclass.')
 
     def __call__(self, *args, **kwargs):
         # this magic method makes a Processor callable
         return self.process(*args, **kwargs)
+
+
+class OnlineProcessor(Processor):
+    """
+    Abstract base class for processing data in online mode.
+
+    Derived classes must implement the following methods:
+
+    - process_online(): process the data in online mode,
+    - process_offline(): process the data in offline mode.
+
+    """
+
+    def __init__(self, online=False):
+        self.online = online
+
+    def process(self, data, **kwargs):
+        """
+        Process the data either in online or offline mode.
+
+        Parameters
+        ----------
+        data : depends on the implementation of subclass
+            Data to be processed.
+        kwargs : dict, optional
+            Keyword arguments for processing.
+
+        Returns
+        -------
+        depends on the implementation of subclass
+            Processed data.
+
+        Notes
+        -----
+        This method is used to pass the data to either `process_online` or
+        `process_offline`, depending on the `online` setting of the processor.
+
+        """
+        if self.online:
+            return self.process_online(data, **kwargs)
+        return self.process_offline(data, **kwargs)
+
+    def process_online(self, data, reset=True, **kwargs):
+        """
+        Process the data in online mode.
+
+        This method must be implemented by the derived class and should process
+        the given data frame by frame and return the processed output.
+
+        Parameters
+        ----------
+        data : depends on the implementation of subclass
+            Data to be processed.
+        reset : bool, optional
+            Reset the processor to its initial state before processing.
+        kwargs : dict, optional
+            Keyword arguments for processing.
+
+        Returns
+        -------
+        depends on the implementation of subclass
+            Processed data.
+
+        """
+        raise NotImplementedError('Must be implemented by subclass.')
+
+    def process_offline(self, data, **kwargs):
+        """
+        Process the data in offline mode.
+
+        This method must be implemented by the derived class and should process
+        the given data and return the processed output.
+
+        Parameters
+        ----------
+        data : depends on the implementation of subclass
+            Data to be processed.
+        kwargs : dict, optional
+            Keyword arguments for processing.
+
+        Returns
+        -------
+        depends on the implementation of subclass
+            Processed data.
+
+        """
+        raise NotImplementedError('Must be implemented by subclass.')
+
+    def reset(self):
+        """
+        Reset the OnlineProcessor.
+
+        This method must be implemented by the derived class and should reset
+        the processor to its initial state.
+
+        """
+        raise NotImplementedError('Must be implemented by subclass.')
 
 
 class OutputProcessor(Processor):
@@ -157,7 +253,7 @@ class OutputProcessor(Processor):
 
         """
         # pylint: disable=arguments-differ
-        raise NotImplementedError('must be implemented by subclass.')
+        raise NotImplementedError('Must be implemented by subclass.')
 
 
 # functions for processing file(s) with a Processor
@@ -198,9 +294,8 @@ def _process(process_tuple):
     elif isinstance(process_tuple[0], Processor):
         # call the Processor with data and kwargs
         return process_tuple[0](*process_tuple[1:-1], **process_tuple[-1])
-    else:
-        # just call whatever we got here (e.g. a function) without kwargs
-        return process_tuple[0](*process_tuple[1:-1])
+    # just call whatever we got here (e.g. a function) without kwargs
+    return process_tuple[0](*process_tuple[1:-1])
 
 
 class SequentialProcessor(MutableSequence, Processor):

--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -765,7 +765,7 @@ class BufferProcessor(Processor):
         # save variables
         self.buffer_size = buffer_size
         self.init = init
-        self.buffer = init
+        self.data = init
 
     def reset(self, init=None):
         """
@@ -777,7 +777,7 @@ class BufferProcessor(Processor):
             Reset BufferProcessor to this initial state.
 
         """
-        self.buffer = init if init is not None else self.init
+        self.data = init if init is not None else self.init
 
     def process(self, data, **kwargs):
         """
@@ -802,13 +802,30 @@ class BufferProcessor(Processor):
         # length of the data
         data_length = len(data)
         # remove `data_length` from buffer at the beginning and append new data
-        self.buffer = np.roll(self.buffer, -data_length, axis=0)
-        self.buffer[-data_length:] = data
+        self.data = np.roll(self.data, -data_length, axis=0)
+        self.data[-data_length:] = data
         # return the complete buffer
-        return self.buffer
+        return self.data
 
     # alias for easier / more intuitive calling
     buffer = process
+
+    def __getitem__(self, index):
+        """
+        Direct access to the buffer data.
+
+        Parameters
+        ----------
+        index : int, slice, ndarray,
+            Any NumPy indexing method to access the buffer data directly.
+
+        Returns
+        -------
+        numpy array or subclass thereof
+            Requested view of the buffered data.
+
+        """
+        return self.data[index]
 
 
 # function to process live input

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -917,6 +917,7 @@ class TestTempoDetectorProgram(unittest.TestCase):
             pj(ACTIVATIONS_PATH, "sample.beats_blstm.npz"))
         self.result = np.loadtxt(
             pj(DETECTIONS_PATH, "sample.tempo_detector.txt"))
+        self.online_results = np.array([176.47, 88.24, 0.58])
 
     def test_help(self):
         self.assertTrue(run_help(self.bin))
@@ -946,6 +947,14 @@ class TestTempoDetectorProgram(unittest.TestCase):
         run_single(self.bin, sample_file, tmp_result)
         result = np.loadtxt(tmp_result)
         self.assertTrue(np.allclose(result, self.result, atol=1e-5))
+
+    def test_online(self):
+        run_online(self.bin, sample_file, tmp_result)
+        result = np.loadtxt(tmp_result)
+        self.assertTrue(np.allclose(result[-1], self.online_results))
+        run_single(self.bin, sample_file, tmp_result, online=True)
+        result = np.loadtxt(tmp_result)
+        self.assertTrue(np.allclose(result, self.online_results))
 
 
 # clean up

--- a/tests/test_features_beats_hmm.py
+++ b/tests/test_features_beats_hmm.py
@@ -25,11 +25,11 @@ class TestBeatStateSpaceClass(unittest.TestCase):
         self.assertIsInstance(bss.num_states, int)
         self.assertIsInstance(bss.num_intervals, int)
         # dtypes
-        self.assertTrue(bss.intervals.dtype == np.uint32)
+        self.assertTrue(bss.intervals.dtype == np.int)
         self.assertTrue(bss.state_positions.dtype == np.float)
-        self.assertTrue(bss.state_intervals.dtype == np.uint32)
-        self.assertTrue(bss.first_states.dtype == np.uint32)
-        self.assertTrue(bss.last_states.dtype == np.uint32)
+        self.assertTrue(bss.state_intervals.dtype == np.int)
+        self.assertTrue(bss.first_states.dtype == np.int)
+        self.assertTrue(bss.last_states.dtype == np.int)
 
     def test_values(self):
         bss = BeatStateSpace(1, 4)
@@ -73,9 +73,8 @@ class TestBarStateSpaceClass(unittest.TestCase):
         self.assertIsInstance(bss.first_states, list)
         self.assertIsInstance(bss.last_states, list)
         # dtypes
-        # self.assertTrue(bss.intervals.dtype == np.uint32)
         self.assertTrue(bss.state_positions.dtype == np.float)
-        self.assertTrue(bss.state_intervals.dtype == np.uint32)
+        self.assertTrue(bss.state_intervals.dtype == np.int)
 
     def test_values(self):
         # 2 beats, intervals 1 to 4
@@ -128,11 +127,8 @@ class TestMultiPatternStateSpaceClass(unittest.TestCase):
         # self.assertIsInstance(mpss.num_intervals, int)
         self.assertIsInstance(mpss.num_patterns, int)
         # dtypes
-        # self.assertTrue(mpss.intervals.dtype == np.uint32)
         self.assertTrue(mpss.state_positions.dtype == np.float)
-        self.assertTrue(mpss.state_intervals.dtype == np.uint32)
-        # self.assertTrue(mpss.first_states.dtype == np.uint32)
-        # self.assertTrue(mpss.last_states.dtype == np.uint32)
+        self.assertTrue(mpss.state_intervals.dtype == np.int)
 
     def test_values_beat(self):
         # test with 2 BeatStateSpaces as before

--- a/tests/test_features_tempo.py
+++ b/tests/test_features_tempo.py
@@ -93,11 +93,9 @@ class TestTempoEstimationProcessorClass(unittest.TestCase):
         self.assertIsInstance(self.processor.max_bpm, float)
         self.assertIsInstance(self.processor.act_smooth, float)
         self.assertIsInstance(self.processor.hist_smooth, int)
-        self.assertIsInstance(self.processor.alpha, float)
         self.assertIsInstance(self.processor.fps, float)
-        # properties
-        self.assertIsInstance(self.processor.min_interval, int)
-        self.assertIsInstance(self.processor.max_interval, int)
+        self.assertIsInstance(self.processor.histogram_processor,
+                              TempoHistogramProcessor)
 
     def test_values(self):
         self.assertTrue(self.processor.method == 'comb')
@@ -105,10 +103,11 @@ class TestTempoEstimationProcessorClass(unittest.TestCase):
         self.assertTrue(self.processor.max_bpm == 250)
         self.assertTrue(self.processor.act_smooth == 0.14)
         self.assertTrue(self.processor.hist_smooth == 9)
-        self.assertTrue(self.processor.alpha == 0.79)
         self.assertTrue(self.processor.fps == 100)
-        self.assertTrue(self.processor.min_interval == 24)
-        self.assertTrue(self.processor.max_interval == 150)
+        # test default values of the histogram processor
+        self.assertTrue(self.processor.histogram_processor.alpha == 0.79)
+        self.assertTrue(self.processor.histogram_processor.min_interval == 24)
+        self.assertTrue(self.processor.histogram_processor.max_interval == 150)
 
     def test_process(self):
         tempi = self.processor(act)

--- a/tests/test_features_tempo.py
+++ b/tests/test_features_tempo.py
@@ -191,6 +191,39 @@ class TestCombFilterTempoHistogramProcessorClass(unittest.TestCase):
                                                     [85.7142857, 0.11437361],
                                                     [115.384615, 0.10919612]]))
 
+    def test_process(self):
+        hist, delays = self.processor(act)
+        self.assertTrue(np.allclose(delays, np.arange(24, 151)))
+        self.assertTrue(np.allclose(hist.max(), 10.5064280455))
+        self.assertTrue(np.allclose(hist.min(), 1.23250838113))
+        self.assertTrue(np.allclose(hist.argmax(), 10))
+        self.assertTrue(np.allclose(hist.argmin(), 44))
+        self.assertTrue(np.allclose(np.sum(hist), 231.568316445))
+        self.assertTrue(np.allclose(np.mean(hist), 1.82337257043))
+        self.assertTrue(np.allclose(np.median(hist), 1.48112542203))
+
+    def test_process_online(self):
+        with self.assertRaises(NotImplementedError):
+            self.online_processor(act)
+        result = [self.online_processor(np.atleast_1d(a), reset=False)
+                  for a in act]
+        # the final result must be the same as for offline processing
+        hist, delays = result[-1]
+        hist_, delays_ = self.processor(act)
+        self.assertTrue(np.allclose(hist, hist_))
+        self.assertTrue(np.allclose(delays, delays_))
+        # result after 100 frames
+        hist, delays = result[99]
+        print(hist.max(), hist.min(), hist.argmax(), hist.argmin())
+        self.assertTrue(np.allclose(hist.max(), 2.03108930086))
+        self.assertTrue(np.allclose(hist.min(), 1.23250838113))
+        self.assertTrue(np.allclose(hist.argmax(), 12))
+        self.assertTrue(np.allclose(hist.argmin(), 44))
+        print(np.sum(hist), np.mean(hist), np.median(hist))
+        self.assertTrue(np.allclose(np.sum(hist), 175.034206851))
+        self.assertTrue(np.allclose(np.mean(hist), 1.37822210119))
+        self.assertTrue(np.allclose(np.median(hist), 1.23250838113))
+
 
 class TestACFTempoHistogramProcessorClass(unittest.TestCase):
 
@@ -238,6 +271,40 @@ class TestACFTempoHistogramProcessorClass(unittest.TestCase):
                                                     [86.95652174, 0.2248635],
                                                     [58.25242718, 0.1878183]]))
 
+    def test_process(self):
+        hist, delays = self.processor(act)
+        self.assertTrue(np.allclose(delays, np.arange(24, 151)))
+        self.assertTrue(np.allclose(hist.max(), 0.772242703961))
+        self.assertTrue(np.allclose(hist.min(), 0.0550745515184))
+        self.assertTrue(np.allclose(hist.argmax(), 11))
+        self.assertTrue(np.allclose(hist.argmin(), 103))
+        self.assertTrue(np.allclose(np.sum(hist), 28.4273056042))
+        self.assertTrue(np.allclose(np.mean(hist), 0.223837052001))
+        self.assertTrue(np.allclose(np.median(hist), 0.147368463433))
+
+    def test_process_online(self):
+        with self.assertRaises(NotImplementedError):
+            self.online_processor(act)
+        result = [self.online_processor(np.atleast_1d(a), reset=False)
+                  for a in act]
+        # the final result must be the same as for offline processing
+        hist, delays = result[-1]
+        hist_, delays_ = self.processor(act)
+        self.assertTrue(np.allclose(hist, hist_))
+        self.assertTrue(np.allclose(delays, delays_))
+        # result after 100 frames
+        hist, delays = result[99]
+        print(hist.max(), hist.min(), hist.argmax(), hist.argmin())
+        self.assertTrue(np.allclose(hist.max(), 0.19544739526))
+        self.assertTrue(np.allclose(hist.min(), 0))
+        self.assertTrue(np.allclose(hist.argmax(), 46))
+        self.assertTrue(np.allclose(hist.argmin(), 76))
+        print(np.sum(hist), np.mean(hist), np.median(hist))
+        self.assertTrue(np.allclose(np.sum(hist), 3.58546628975))
+        self.assertTrue(np.allclose(np.mean(hist), 0.0282320180295))
+        self.assertTrue(np.allclose(np.median(hist), 0.00471735456373))
+
+
 
 class TestDBNTempoHistogramProcessorClass(unittest.TestCase):
 
@@ -277,6 +344,28 @@ class TestDBNTempoHistogramProcessorClass(unittest.TestCase):
         tempo_processor.reset()
         tempi = [tempo_processor(np.atleast_2d(a), reset=False) for a in act]
         self.assertTrue(np.allclose(tempi[-1], DBN_TEMPI))
+
+    def test_process(self):
+        hist, delays = self.processor(act)
+        self.assertTrue(np.allclose(delays, np.arange(24, 151)))
+        self.assertTrue(np.allclose(hist.max(), 281))
+        self.assertTrue(np.allclose(hist.min(), 0))
+        self.assertTrue(np.allclose(hist.argmax(), 10))
+        self.assertTrue(np.allclose(hist.argmin(), 0))
+        self.assertTrue(np.allclose(np.sum(hist), 281))
+        self.assertTrue(np.allclose(np.mean(hist), 2.2125984252))
+        self.assertTrue(np.allclose(np.median(hist), 0))
+
+    def test_process_online(self):
+        hist, delays = self.online_processor(act)
+        self.assertTrue(np.allclose(delays, np.arange(24, 151)))
+        self.assertTrue(np.allclose(hist.max(), 106))
+        self.assertTrue(np.allclose(hist.min(), 0))
+        self.assertTrue(np.allclose(hist.argmax(), 10))
+        self.assertTrue(np.allclose(hist.argmin(), 1))
+        self.assertTrue(np.allclose(np.sum(hist), 281))
+        self.assertTrue(np.allclose(np.mean(hist), 2.2125984252))
+        self.assertTrue(np.allclose(np.median(hist), 0))
 
 
 class TestWriteTempoFunction(unittest.TestCase):

--- a/tests/test_features_tempo.py
+++ b/tests/test_features_tempo.py
@@ -19,6 +19,11 @@ fps = float(act_file['fps'])
 
 COMB_TEMPI = np.array([[176.470, 0.475], [117.647, 0.177],
                        [240.0, 0.154], [68.966, 0.099], [82.192, 0.096]])
+COMB_TEMPI_ONLINE = [[176.470588, 0.289414003], [115.384615, 0.124638601],
+                     [230.769231, 0.0918372569], [84.5070423, 0.0903815502],
+                     [75.0000000, 0.0713704506], [53.5714286, 0.0701783497],
+                     [65.9340659, 0.0696296514], [49.1803279, 0.0676349815],
+                     [61.2244898, 0.0646209647], [40.8163265, 0.0602941909]]
 
 HIST = interval_histogram_comb(act, 0.79, min_tau=24, max_tau=150)
 
@@ -112,6 +117,72 @@ class TestTempoEstimationProcessorClass(unittest.TestCase):
     def test_process(self):
         tempi = self.processor(act)
         self.assertTrue(np.allclose(tempi, COMB_TEMPI, atol=0.01))
+
+    def test_process_online(self):
+        processor = TempoEstimationProcessor(fps=fps, online=True)
+        tempi = [processor.process_online(np.atleast_1d(a), reset=False)
+                 for a in act]
+        self.assertTrue(np.allclose(tempi[-1], COMB_TEMPI_ONLINE))
+        # with resetting results are the same
+        processor.reset()
+        tempi = [processor.process_online(np.atleast_1d(a), reset=False)
+                 for a in act]
+        self.assertTrue(np.allclose(tempi[-1], COMB_TEMPI_ONLINE))
+        # without resetting results are different
+        tempi = [processor.process_online(np.atleast_1d(a), reset=False)
+                 for a in act]
+        self.assertTrue(np.allclose(tempi[-1][:3], [[176.470588, 0.31322337],
+                                                    [85.7142857, 0.11437361],
+                                                    [115.384615, 0.10919612]]))
+
+
+class TestCombFilterTempoHistogramProcessorClass(unittest.TestCase):
+
+    def setUp(self):
+        self.processor = CombFilterTempoHistogramProcessor(fps=fps)
+        self.online_processor = CombFilterTempoHistogramProcessor(fps=fps,
+                                                                  online=True)
+
+    def test_types(self):
+        self.assertIsInstance(self.processor.min_bpm, float)
+        self.assertIsInstance(self.processor.max_bpm, float)
+        self.assertIsInstance(self.processor.alpha, float)
+        self.assertIsInstance(self.processor.fps, float)
+        # properties
+        self.assertIsInstance(self.processor.min_interval, int)
+        self.assertIsInstance(self.processor.max_interval, int)
+
+    def test_values(self):
+        self.assertTrue(self.processor.min_bpm == 40)
+        self.assertTrue(self.processor.max_bpm == 250)
+        self.assertTrue(self.processor.alpha == 0.79)
+        self.assertTrue(self.processor.fps == 100)
+        self.assertTrue(self.processor.min_interval == 24)
+        self.assertTrue(self.processor.max_interval == 150)
+
+    def test_tempo(self):
+        tempo_processor = TempoEstimationProcessor(
+            histogram_processor=self.processor, fps=fps)
+        tempi = tempo_processor(act)
+        self.assertTrue(np.allclose(tempi, COMB_TEMPI, atol=0.01))
+
+    def test_tempo_online(self):
+        tempo_processor = TempoEstimationProcessor(
+            histogram_processor=self.online_processor, fps=fps, online=True)
+        tempi = [tempo_processor.process_online(np.atleast_1d(a), reset=False)
+                 for a in act]
+        self.assertTrue(np.allclose(tempi[-1], COMB_TEMPI_ONLINE))
+        # with resetting results are the same
+        tempo_processor.reset()
+        tempi = [tempo_processor.process_online(np.atleast_1d(a), reset=False)
+                 for a in act]
+        self.assertTrue(np.allclose(tempi[-1], COMB_TEMPI_ONLINE))
+        # without resetting results are different
+        tempi = [tempo_processor.process_online(np.atleast_1d(a), reset=False)
+                 for a in act]
+        self.assertTrue(np.allclose(tempi[-1][:3], [[176.470588, 0.31322337],
+                                                    [85.7142857, 0.11437361],
+                                                    [115.384615, 0.10919612]]))
 
 
 class TestWriteTempoFunction(unittest.TestCase):

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -8,7 +8,6 @@ This file contains tests for the madmom.processors module.
 from __future__ import absolute_import, division, print_function
 import tempfile
 import unittest
-import sys
 
 from madmom.processors import *
 from madmom.models import *
@@ -70,6 +69,14 @@ class TestBufferProcessor(unittest.TestCase):
         result = buffer(np.arange(8, 14).reshape((3, -1)))
         self.assertTrue(result.shape == (5, 2))
         self.assertTrue(np.allclose(result.ravel(), np.arange(4, 14)))
+
+    def test_reset(self):
+        buffer = BufferProcessor(5, init=np.ones(5))
+        self.assertTrue(np.allclose(buffer.buffer, 1))
+        result = buffer(np.arange(2))
+        self.assertTrue(np.allclose(result, [1, 1, 1, 0, 1]))
+        buffer.reset()
+        self.assertTrue(np.allclose(buffer.buffer, 1))
 
 
 # clean up

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -30,7 +30,7 @@ class TestBufferProcessor(unittest.TestCase):
 
     def test_1d(self):
         buffer = BufferProcessor(5, init=np.zeros(5))
-        self.assertTrue(np.allclose(buffer.buffer, 0))
+        self.assertTrue(np.allclose(buffer.data, 0))
         # shift in two new values
         result = buffer(np.arange(2))
         self.assertTrue(np.allclose(result, [0, 0, 0, 0, 1]))
@@ -44,9 +44,9 @@ class TestBufferProcessor(unittest.TestCase):
 
     def test_2d(self):
         buffer = BufferProcessor((5, 2), init=np.zeros((5, 2)))
-        print(buffer.buffer)
-        self.assertTrue(buffer.buffer.shape == (5, 2))
-        self.assertTrue(np.allclose(buffer.buffer, 0))
+        print(buffer.data)
+        self.assertTrue(buffer.data.shape == (5, 2))
+        self.assertTrue(np.allclose(buffer.data, 0))
         # shift in new values
         result = buffer(np.arange(2).reshape((1, -1)))
         self.assertTrue(result.shape == (5, 2))
@@ -72,11 +72,11 @@ class TestBufferProcessor(unittest.TestCase):
 
     def test_reset(self):
         buffer = BufferProcessor(5, init=np.ones(5))
-        self.assertTrue(np.allclose(buffer.buffer, 1))
+        self.assertTrue(np.allclose(buffer.data, 1))
         result = buffer(np.arange(2))
         self.assertTrue(np.allclose(result, [1, 1, 1, 0, 1]))
         buffer.reset()
-        self.assertTrue(np.allclose(buffer.buffer, 1))
+        self.assertTrue(np.allclose(buffer.data, 1))
 
 
 # clean up


### PR DESCRIPTION
This PR makes `TempoEstimationProcessor` online capable.

`TempoEstimationProcessor.interval_histogram` is refactored to use a dedicated histogram processor which is used to build the beat interval histogram. Different `TempoHistogramProcessor` classes provide the needed functionality for both online and offline mode, namely CombFilter, ACF and DBN. With the work done in #286 this change was unavoidable, otherwise `TempoEstimationProcessor` would have had too many options and parameters.

TODOs before this PR can be merged:

- [x] Make these histogram processors capable of processing the activations as a whole (i.e. `single --online` mode) or frame by frame (i.e. `online` mode).
- [x] Add option to set length of history to be considered when "integrating" the tempo. E.g. in offline mode comb filter histogram building sums all maxima of a musical piece. In online mode simply summing all values is not practicable, otherwise tempo changes cannot be tracked.
- [x] Decide if we want to keep `interval_histogram` and `interval_histogram_online` methods or refactor the histogram stuff into dedicated classes (with the usual `process_offline` and `process_online` methods).
- [x] Decide the output frequency in online mode, i.e. when to output the tempi. Output for every frame or whenever the tempo changes? Maybe this should be controllable via a parameter. (**EDIT:** outputting it at every frame now, could be changed easily if needed)
- [x] Add activation smoothing for online mode? (**EDIT:** see #343)
- [x] Refactor the visualisation stuff as mixins (**EDIT:** see #344)