### PR TITLE
Fixed BeatTracker double detections

### DIFF
--- a/madmom/features/beats.py
+++ b/madmom/features/beats.py
@@ -532,6 +532,8 @@ class BeatTrackingProcessor(Processor):
 
         # convert detected beats to a list of timestamps
         detections = np.array(detections) / float(self.fps)
+        # make detections unique
+        detections = np.unique(detections)
         # remove beats with negative times and return them
         return detections[np.searchsorted(detections, 0):]
         # only return beats with a bigger inter beat interval than that of the


### PR DESCRIPTION
The BeatTracker sometimes yield double detections which then result in errors when evaluating.
I just added an additional _np.unique_ before returning the detections.

If further investigation is needed I can send activations which will produce such double detections.

Regards, Sebi