### PR TITLE
fix situation where beats get detected multiple times

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 0.16.dev0
 Bug fixes:
 
 * Fix `TransitionModel` number of states when last state is unreachable (#287)
+* Fix double beat detections in `BeatTrackingProcessor` (#298)
 
 Other changes:
 

--- a/madmom/features/beats.py
+++ b/madmom/features/beats.py
@@ -524,6 +524,10 @@ class BeatTrackingProcessor(Processor):
                 positions = detect_beats(act, interval, self.look_aside)
                 # correct the beat positions
                 positions += start
+                # remove all positions < already detected beats + min_interval
+                next_pos = (detections[-1] + self.tempo_estimator.min_interval
+                            if detections else 0)
+                positions = positions[positions >= next_pos]
                 # search the closest beat to the predicted beat position
                 pos = positions[(np.abs(positions - pos)).argmin()]
                 # append to the beats
@@ -534,10 +538,6 @@ class BeatTrackingProcessor(Processor):
         detections = np.array(detections) / float(self.fps)
         # remove beats with negative times and return them
         return detections[np.searchsorted(detections, 0):]
-        # only return beats with a bigger inter beat interval than that of the
-        # maximum allowed tempo
-        # return np.append(detections[0], detections[1:][np.diff(detections) >
-        #                                                (60. / max_bpm)])
 
     @staticmethod
     def add_arguments(parser, look_aside=LOOK_ASIDE,


### PR DESCRIPTION
This situation can occur if the detected tempo changes when iteratively
searching for the next beat in the given activation function +/- a certain
window. Require the next beat to be at least the last detected one plus the
minimum interval. Fixes #297.