### PR TITLE
DBNBeatTrackingProcessor expects 1D inputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ Bug fixes:
 * Fix `TransitionModel` number of states when last state is unreachable (#287)
 * Fix double beat detections in `BeatTrackingProcessor` (#298)
 
+API relevant changes:
+
+* `DBNBeatTrackingProcessor` expects 1D inputs (#299)
+
+
 Other changes:
 
 * Viterbi decoding of `HMM` raises a warning if no valid path is found (#279)

--- a/madmom/features/beats.py
+++ b/madmom/features/beats.py
@@ -1107,8 +1107,6 @@ class DBNBeatTrackingProcessor(Processor):
             Detected beat position [seconds].
 
         """
-        # make the activations a 1D array
-        activations = np.atleast_1d(activations)
         # reset to initial state
         if reset:
             self.reset()

--- a/tests/test_features_beats.py
+++ b/tests/test_features_beats.py
@@ -145,12 +145,12 @@ class TestDBNBeatTrackingProcessorClass(unittest.TestCase):
         self.assertTrue(np.allclose(beats, [0.47, 0.79, 1.48, 2.16, 2.5]))
         # compute the forward path framewise
         processor.reset()
-        beats = [processor.process_forward(act, reset=False)
+        beats = [processor.process_forward(np.atleast_1d(act), reset=False)
                  for act in sample_lstm_act]
         self.assertTrue(np.allclose(np.nonzero(beats),
                                     [47, 79, 148, 216, 250]))
         # without resetting results are different
-        beats = [processor.process_forward(act, reset=False)
+        beats = [processor.process_forward(np.atleast_1d(act), reset=False)
                  for act in sample_lstm_act]
         self.assertTrue(np.allclose(np.nonzero(beats), [3, 79, 149, 216, 252]))
 


### PR DESCRIPTION
removed np.atleast_1d from process_forward since it has a rather large overhead