### PR TITLE
[WIP] fix reference leaks

### DIFF
--- a/madmom/audio/signal.py
+++ b/madmom/audio/signal.py
@@ -1450,7 +1450,7 @@ class FramedSignalProcessor(Processor):
         # always use the last `frame_size` samples if we operate on a live
         # audio stream, otherwise we get the wrong portion of the signal
         if self.origin == 'stream':
-            data = data[-self.frame_size:]
+            data = data[-self.frame_size:, ]
         # instantiate a FramedSignal from the data and return it
         return FramedSignal(data, **args)
 

--- a/madmom/audio/signal.py
+++ b/madmom/audio/signal.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, division, print_function
 
 import errno
 import numpy as np
+import objgraph
 
 from madmom.processors import Processor, BufferProcessor
 
@@ -1418,6 +1419,7 @@ class FramedSignalProcessor(Processor):
         self.origin = origin
         self.end = end
         self.num_frames = num_frames
+        self.num_slices = 0
 
     def process(self, data, **kwargs):
         """
@@ -1436,6 +1438,10 @@ class FramedSignalProcessor(Processor):
             FramedSignal instance
 
         """
+        num_slices = len(objgraph.by_type('slice'))
+        print('DEBUG: leaking %d references (%d total)' %
+              (num_slices - self.num_slices, num_slices))
+        self.num_slices = num_slices
         # update arguments passed to FramedSignal
         args = dict(frame_size=self.frame_size, hop_size=self.hop_size,
                     fps=self.fps, origin=self.origin, end=self.end,


### PR DESCRIPTION
## Changes proposed in this pull request

- Fix a leak of `slice` references.

Without the second commit Python 2.7 leaks 15 references per frame, with it only 12.
However, I was not able to track this down completely.

This pull request fixes #321 -- at least partially.

### Remaining TODOs before this pull request can be merged

- [ ] Check if this can be fixed completely, since Python 3 (I checked 3.5) does not show the same behaviour.