### PR TITLE
fix online docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 # fake requirements for readthedocs
 cython
 numpydoc
+mido

--- a/madmom/features/downbeats.py
+++ b/madmom/features/downbeats.py
@@ -927,7 +927,7 @@ class RNNBarProcessor(Processor):
     ----------
     .. [1] Florian Krebs, Sebastian Böck and Gerhard Widmer,
            "Downbeat Tracking Using Beat-Synchronous Features and Recurrent
-            Networks",
+           Networks",
            Proceedings of the 17th International Society for Music Information
            Retrieval Conference (ISMIR), 2016.
 


### PR DESCRIPTION
## Changes proposed in this pull request

The latest merge caused the online docs to fail (see #360). This PR adds the missing dependency to successfully build the online docs for [madmom.readthedocs.io](madmom.readthedocs.io).

Additionally, it fixes some shpinx rendering issues. Closes #360.