### PR TITLE
use pyfftw for FFT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
   - sudo add-apt-repository --yes ppa:jonathonf/ffmpeg-3
   - sudo apt-get update -qq
   - sudo apt-get install -qq ffmpeg
+  - sudo apt-get install -qq libfftw3-dev
   # install numpy etc. via miniconda
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
@@ -38,7 +39,7 @@ before_install:
   - deps='pip libgfortran cython numpy scipy nose pep8'
   - conda create -q -n test-environment "python=$TRAVIS_PYTHON_VERSION" $deps
   - source activate test-environment
-  - pip install codecov mido
+  - pip install codecov mido pyfftw
 install:
   - pip install -e .
   - pip install coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Other changes:
 
 * Viterbi decoding of `HMM` raises a warning if no valid path is found (#279)
 * Add option to include Nyquist frequency in `STFT` (#280)
+* Use `pyfftw` to compute FFT (#363)
 
 
 Version 0.15.1 (release date: 2017-07-07)

--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,7 @@ To install the ``madmom`` package, you must have either Python 2.7 or Python
 - `nose <https://github.com/nose-devs/nose>`_ (to run the tests)
 - `pyaudio <http://people.csail.mit.edu/hubert/pyaudio/>`_ (to process live
   audio input)
+- `pyfftw <https://github.com/pyFFTW/pyFFTW/>`_ (for better FFT performance)
 
 If you need support for audio files other than ``.wav`` with a sample rate of
 44.1kHz and 16 bit depth, you need ``ffmpeg`` (``avconv`` on Ubuntu Linux has

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.13.4
 scipy>=0.16
 cython>=0.25
 mido
+pyfftw>=0.10.4


### PR DESCRIPTION
## Changes proposed in this pull request

Use pyfftw (if available) to compute FFT. Gives up to 40% faster FFT computation.