### PR TITLE
integer_types

### DIFF
--- a/madmom/audio/signal.py
+++ b/madmom/audio/signal.py
@@ -13,6 +13,7 @@ import warnings
 import numpy as np
 
 from ..processors import BufferProcessor, Processor
+from ..utils import integer_types
 
 
 # signal functions
@@ -42,7 +43,7 @@ def smooth(signal, kernel):
     if kernel is None:
         return signal
     # size for the smoothing kernel is given
-    elif isinstance(kernel, (int, np.integer)):
+    elif isinstance(kernel, integer_types):
         if kernel == 0:
             return signal
         elif kernel > 1:
@@ -1121,7 +1122,7 @@ class FramedSignal(object):
 
         """
         # a single index is given
-        if isinstance(index, int):
+        if isinstance(index, integer_types):
             # negative indices
             if index < 0:
                 index += self.num_frames
@@ -1321,7 +1322,7 @@ class FramedSignalProcessor(Processor):
         # add signal framing options to the existing parser
         g = parser.add_argument_group('signal framing arguments')
         # depending on the type of frame_size, use different options
-        if isinstance(frame_size, int):
+        if isinstance(frame_size, integer_types):
             g.add_argument('--frame_size', action='store', type=int,
                            default=frame_size,
                            help='frame size [samples, default=%(default)i]')

--- a/madmom/features/downbeats.py
+++ b/madmom/features/downbeats.py
@@ -22,6 +22,7 @@ from .beats_hmm import (BarStateSpace, BarTransitionModel,
                         RNNDownBeatTrackingObservationModel, )
 from ..ml.hmm import HiddenMarkovModel
 from ..processors import ParallelProcessor, Processor, SequentialProcessor
+from ..utils import string_types
 
 
 # downbeat tracking, i.e. track beats and downbeats directly from signal
@@ -772,7 +773,7 @@ class LoadBeatsProcessor(Processor):
         import os
         from ..utils import match_file
 
-        if not isinstance(filename, str):
+        if not isinstance(filename, string_types):
             raise SystemExit('Please supply a filename, not %s.' % filename)
         # select the matching beat file to a given input file from all files
         basename, ext = os.path.splitext(os.path.basename(filename))

--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -24,6 +24,8 @@ from collections import MutableSequence
 
 import numpy as np
 
+from .utils import integer_types
+
 
 class Processor(object):
     """
@@ -756,7 +758,7 @@ class BufferProcessor(Processor):
         if buffer_size is None and init is not None:
             buffer_size = init.shape
         # if buffer_size is int, make a tuple
-        elif isinstance(buffer_size, (int, np.integer)):
+        elif isinstance(buffer_size, integer_types):
             buffer_size = (buffer_size, )
         # TODO: use np.pad for fancy initialisation (can be done in process())
         # init buffer if needed

--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -530,7 +530,7 @@ class IOProcessor(OutputProcessor):
         else:
             self.in_processor = in_processor
         # wrap the output processor in an IOProcessor if needed
-        if isinstance(out_processor, list):
+        if isinstance(out_processor, (list, tuple)):
             if len(out_processor) >= 2:
                 # use the last processor as output and all others as input
                 self.out_processor = IOProcessor(out_processor[:-1],

--- a/madmom/utils/__init__.py
+++ b/madmom/utils/__init__.py
@@ -19,8 +19,10 @@ import numpy as np
 # Python 2/3 string compatibility (like six does it)
 try:
     string_types = basestring
+    integer_types = (int, long, np.integer)
 except NameError:
     string_types = str
+    integer_types = (int, np.integer)
 
 
 # decorator to suppress warnings

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -1262,6 +1262,15 @@ class TestFramedSignalClass(unittest.TestCase):
                                     [-9.03089987, -4.25968732, -3.01029996,
                                      -4.25968732, -4.25968732]))
 
+    def test_iterating(self):
+        frames = FramedSignal(sig_1d, frame_size=4, hop_size=2)
+        res = frames[range(frames.num_frames)[0]]
+        res = frames[np.arange(frames.num_frames)[0]]
+        res = frames[np.arange(frames.num_frames, dtype=np.long)[0]]
+        if sys.version_info[0] == 2:
+            res = frames[xrange(frames.num_frames)[0]]
+            res = frames[long(range(frames.num_frames)[0])]
+
 
 class TestFramedSignalProcessorClass(unittest.TestCase):
 


### PR DESCRIPTION
## Changes proposed in this pull request

Add `integer_types` to contain `int`, `np.integer` and `long` in Python 2.
Whenever `isinstance` is used to test integer values, `integer_types` is used.

This PR additionally addresses one usage of `str` instead of `string_types` and another missing test against `tuple`; fixes #364.
