### PR TITLE
remix Signal according to num_channels if instantiated from array

### DIFF
--- a/madmom/audio/signal.py
+++ b/madmom/audio/signal.py
@@ -600,6 +600,9 @@ class Signal(np.ndarray):
         if not isinstance(data, Signal):
             data = np.asarray(data).view(cls)
             data.sample_rate = sample_rate
+        # remix to desired number of channels
+        if num_channels:
+            data = remix(data, num_channels)
         # normalize signal if needed
         if norm:
             data = normalize(data)

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -749,6 +749,12 @@ class TestSignalClass(unittest.TestCase):
         self.assertTrue(result.length == 9 / 12.3)
         self.assertTrue(result.ndim == 2)
 
+    def test_num_channels(self):
+        result = Signal(sig_2d, sample_rate=1, num_channels=1)
+        self.assertTrue(result.shape == (9, ))
+        self.assertTrue(np.allclose(result,
+                                    [0.5, 0, 1, 0, 0.5, 0.5, 0.5, 0, 1]))
+
     def test_values_file(self):
         result = Signal(sample_file)
         self.assertTrue(np.allclose(result[:5],


### PR DESCRIPTION
## Changes proposed in this pull request

If `Signal` is instantiated from array, `num_channels` is respected and data remixed if needed. 

This pull request fixes #367.