### PR TITLE
flush output immediately

### DIFF
--- a/madmom/io/__init__.py
+++ b/madmom/io/__init__.py
@@ -118,6 +118,7 @@ def write_events(events, filename, fmt='%.3f', delimiter='\t', header=None):
             except TypeError:
                 string = fmt % e
             f.write(bytes((string + '\n').encode(ENCODING)))
+            f.flush()
 
 
 load_onsets = load_events


### PR DESCRIPTION
fixes #382

## Changes proposed in this pull request

Please provide a detailed description of the changes proposed in this pull
request. This can either be a textual description or a simple list.

flush output immediately. In Python 3 content of the output buffer get flushed only in certain intervals. For online mode, immediate flushing is required though.

This pull request fixes #382.