### PR TITLE
backport 0.16.1 changes: include .pyx files in source distributions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Release Notes
 Version 0.17.dev0
 -----------------
 
+Version 0.16.1 (release date: 2017-11-14)
+-----------------------------------------
+
+This is a maintenance release.
+
+* Include .pyx files in source distribution
 
 Version 0.16 (release date: 2017-11-13)
 ---------------------------------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 prune docs
 prune tests
 include CHANGES.rst
+recursive-include madmom/ *.pyx


### PR DESCRIPTION
## Changes proposed in this pull request

Due to whatever reason the `.pyx` files were not included in the source distribution uploaded to PyPI. This PR backports the changes made for v0.16.1