### PR TITLE
DBNBarTrackingProcessor can model a single bar length

### DIFF
--- a/madmom/features/beats_hmm.py
+++ b/madmom/features/beats_hmm.py
@@ -463,11 +463,13 @@ class MultiPatternTransitionModel(TransitionModel):
         if isinstance(transition_prob, float) and transition_prob:
             # create a pattern transition probability matrix
             self.transition_prob = np.ones((num_patterns, num_patterns))
-            # transition to other patterns
-            self.transition_prob *= transition_prob / (num_patterns - 1)
-            # transition to same pattern
-            diag = np.diag_indices_from(self.transition_prob)
-            self.transition_prob[diag] = 1. - transition_prob
+            # if there is more than 1 pattern, create transitions between them
+            if num_patterns > 1:
+                # transition to other patterns
+                self.transition_prob *= transition_prob / (num_patterns - 1)
+                # transition to same pattern
+                diag = np.diag_indices_from(self.transition_prob)
+                self.transition_prob[diag] = 1. - transition_prob
         else:
             self.transition_prob = transition_prob
         # update/add transitions between patterns

--- a/madmom/features/downbeats.py
+++ b/madmom/features/downbeats.py
@@ -1089,7 +1089,9 @@ class DBNBarTrackingProcessor(Processor):
                  observation_weight=OBSERVATION_WEIGHT,
                  meter_change_prob=METER_CHANGE_PROB, **kwargs):
         # pylint: disable=unused-argument
-        # save variables
+        from madmom.utils import integer_types
+        if isinstance(beats_per_bar, integer_types):
+            beats_per_bar = (beats_per_bar, )
         self.beats_per_bar = beats_per_bar
         # state space & transition model for each bar length
         state_spaces = []

--- a/tests/test_features_downbeats.py
+++ b/tests/test_features_downbeats.py
@@ -205,3 +205,9 @@ class TestDBNBarTrackingProcessorClass(unittest.TestCase):
         beats = self.processor(sample_bar_act)
         self.assertTrue(np.allclose(beats, [[0.0913, 1.], [0.7997, 2.],
                                             [1.4806, 3.], [2.1478, 1.]]))
+
+    def test_single_bar_length(self):
+        processor = DBNBarTrackingProcessor(beats_per_bar=3)
+        beats = processor(sample_bar_act)
+        self.assertTrue(np.allclose(beats, [[0.0913, 1.], [0.7997, 2.],
+                                            [1.4806, 3.], [2.1478, 1.]]))


### PR DESCRIPTION
fixes #393

DBNBarTrackingProcessor should be able to model a single pattern/bar length, given as an integer `beats_per_bar` value.