### PR TITLE
BufferProcessor can handle data longer than buffer length

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Release Notes
 Version 0.17.dev0
 -----------------
 
+Bug fixes:
+
+* `BufferProcessor` can handle data longer than buffer length (#398)
+
 Version 0.16.1 (release date: 2017-11-14)
 -----------------------------------------
 

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -41,6 +41,9 @@ class TestBufferProcessor(unittest.TestCase):
         # shift in three new values
         result = buffer(np.arange(6, 9))
         self.assertTrue(np.allclose(result, [4, 5, 6, 7, 8]))
+        # shift in six new values (bigger than buffer)
+        result = buffer(np.arange(9, 15))
+        self.assertTrue(np.allclose(result, [10, 11, 12, 13, 14]))
 
     def test_2d(self):
         buffer = BufferProcessor((5, 2), init=np.zeros((5, 2)))
@@ -68,6 +71,10 @@ class TestBufferProcessor(unittest.TestCase):
         result = buffer(np.arange(8, 14).reshape((3, -1)))
         self.assertTrue(result.shape == (5, 2))
         self.assertTrue(np.allclose(result.ravel(), np.arange(4, 14)))
+        # shift in six new values (bigger than buffer)
+        result = buffer(np.arange(14, 26).reshape((6, -1)))
+        self.assertTrue(result.shape == (5, 2))
+        self.assertTrue(np.allclose(result.ravel(), np.arange(16, 26)))
 
     def test_reset(self):
         buffer = BufferProcessor(5, init=np.ones(5))


### PR DESCRIPTION


## Changes proposed in this pull request

`BufferProcessor` can handle data longer than it's internal buffer.
Credits: @SebastianPoell with his initial PR #379.

This pull request fixes #378, closes #379.