### PR TITLE
Downbeats: allow weighting of beats per bar

### DIFF
--- a/tests/test_features_downbeats.py
+++ b/tests/test_features_downbeats.py
@@ -101,6 +101,16 @@ class TestDBNDownBeatTrackingProcessorClass(unittest.TestCase):
         downbeats = self.processor(sample_downbeat_act)
         self.assertTrue(np.allclose(downbeats, np.empty((0, 2))))
 
+    def test_weighting_measure(self):
+        self.processor = DBNDownBeatTrackingProcessor(
+            [3, 4], fps=sample_downbeat_act.fps,
+            beats_per_bar_weights=[100, 1], correct=False)
+        downbeats = self.processor(sample_downbeat_act)
+        correct = np.array([[0.08, 1], [0.43, 2], [0.77, 3],
+                            [1.11, 1], [1.45, 2], [1.79, 3],
+                            [2.13, 1], [2.47, 2]])
+        self.assertTrue(np.allclose(downbeats, correct))
+
 
 class TestPatternTrackingProcessorClass(unittest.TestCase):
 


### PR DESCRIPTION
## Changes proposed in this pull request

 * In the `DBNDownBeatTrackingProcessor`, add an optional weighting array parameter, implicitly defaulting to ones
 * Clean up the handling of lengths into the constructor, it was getting verbose
 * Check weights don't sum to zero, to avoid divide-by-zero pain.
 * Weight the HMM results in log space by normalised weight values, as suggested by @Superbock
 * Add new test to prove that (sufficient, but arbitrary) weighting to 3-time (over 4-time)
   does indeed return 3-time beats results.

This fixes #402.

