### PR TITLE
Allow reading audio from file objects created in memory 

### DIFF
--- a/tests/test_io_audio.py
+++ b/tests/test_io_audio.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 
 import unittest
 from os.path import join as pj
+import io
 
 from madmom.io.audio import *
 from . import AUDIO_PATH, DATA_PATH
@@ -33,8 +34,8 @@ class TestLoadWaveFileFunction(unittest.TestCase):
 
     def test_file_handle(self):
         # open file handle
-        file_handle = open(sample_file, 'rb')
-        signal, sample_rate = load_wave_file(file_handle)
+        with open(sample_file, 'rb') as file_handle:
+            signal, sample_rate = load_wave_file(file_handle)
         self.assertIsInstance(signal, np.ndarray)
         self.assertTrue(signal.dtype == np.int16)
         self.assertTrue(type(sample_rate) == int)
@@ -153,7 +154,7 @@ class TestLoadAudioFileFunction(unittest.TestCase):
 
     def test_file_handle(self):
         # test wave loader
-        file_handle = open(sample_file)
+        file_handle = open(sample_file, 'rb')
         signal, sample_rate = load_audio_file(file_handle)
         self.assertIsInstance(signal, np.ndarray)
         self.assertTrue(signal.dtype == np.int16)
@@ -165,7 +166,7 @@ class TestLoadAudioFileFunction(unittest.TestCase):
         self.assertTrue(signal.dtype == np.int16)
         self.assertTrue(type(sample_rate) == int)
         # test ffmpeg loader
-        file_handle = open(sample_file)
+        file_handle = open(sample_file, 'rb')
         signal, sample_rate = load_audio_file(file_handle)
         self.assertIsInstance(signal, np.ndarray)
         self.assertTrue(signal.dtype == np.int16)
@@ -346,6 +347,16 @@ class TestDecodeToDisk(unittest.TestCase):
             data = np.frombuffer(f.read(), dtype=np.int16).reshape((-1, 2))
             adjusted_spl = Signal(data).spl()
         self.assertGreater(orig_spl, adjusted_spl)
+
+
+class TestLoadAudioFromFileObject(unittest.TestCase):
+
+    def test_file_object(self):
+        for file_path in [sample_file, flac_file]:
+            disk_signal = Signal(file_path)
+            with open(file_path, 'rb') as file_handle:
+                memory_signal = Signal(io.BytesIO(file_handle.read()))
+            self.assertTrue((disk_signal == memory_signal).all)
 
 
 # clean up


### PR DESCRIPTION
## Changes proposed in this pull request

These changes allow to read audio from file-like objects created in memory (using BytesIO). The first commit contains the actual changes and the second commit implements a unit test.

The original code was able to read audio from physical file handles, but did so in a way that claimed resource ownership instead of leaving it with the calling code (meaning that if you passed a file handle on to madmom I/O, it got closed afterwards, whether you like it or not and there's nothing you can do about it). A side effect of my implementation is that it got rid of this (in my eyes undesirable) behaviour, but then I noticed that a unit test case was written to explicitly verify this behaviour. So I added a third commit to restore the resource management to its original behaviour, but I would advise you to reconsider it (and change the corresponding unit tests).