### PR TITLE
Load sustained notes

### DIFF
--- a/madmom/io/midi.py
+++ b/madmom/io/midi.py
@@ -557,14 +557,16 @@ class MIDIFile(mido.MidiFile):
             self._save(f)
 
 
-def load_midi(filename):
+def load_midi(filename, sustain=False):
     """
     Load notes from a MIDI file.
 
     Parameters
     ----------
-    filename: str
+    filename : str
         MIDI file.
+    sustain : bool, optional
+        Apply sustain information to the notes.
 
     Returns
     -------
@@ -572,6 +574,8 @@ def load_midi(filename):
         Notes ('onset time' 'note number' 'duration' 'velocity' 'channel')
 
     """
+    if sustain:
+        return MIDIFile(filename).sustained_notes
     return MIDIFile(filename).notes
 
 

--- a/tests/test_io_midi.py
+++ b/tests/test_io_midi.py
@@ -129,6 +129,13 @@ class TestLoadMidiFunction(unittest.TestCase):
         notes_txt = np.loadtxt(pj(ANNOTATIONS_PATH, 'stereo_sample.notes'))
         self.assertTrue(np.allclose(notes[:, :4], notes_txt, atol=1e-3))
 
+    def test_load_midi_sustained(self):
+        notes = load_midi(pj(ANNOTATIONS_PATH, 'stereo_sample_sustained.mid'))
+        self.assertTrue(np.allclose(notes[0, 2], 3.32291667))
+        notes = load_midi(pj(ANNOTATIONS_PATH, 'stereo_sample_sustained.mid'),
+                          sustain=True)
+        self.assertTrue(np.allclose(notes[0, 2], 4.00208333))
+
 
 # clean up
 def teardown_module():


### PR DESCRIPTION
## Changes proposed in this pull request

Add an option to `madmom.io.midi.load_midi()` which allows to load notes from MIDI files with sustain information applied.