### PR TITLE
do not package cythonised .c files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ prune docs
 prune tests
 include CHANGES.rst
 recursive-include madmom/ *.pyx
+recursive-exclude madmom/ *.c


### PR DESCRIPTION
## Changes proposed in this pull request

Packing cythonised `.c` files can lead to failing PyPI installs on systems with older (but still compatible) numpy/cython versions. This pull request fixes #422.
