### PR TITLE
return no beats if no Viterbi path could be found

### DIFF
--- a/madmom/features/beats.py
+++ b/madmom/features/beats.py
@@ -951,11 +951,14 @@ class DBNBeatTrackingProcessor(OnlineProcessor):
         if self.threshold:
             activations, first = threshold_activations(activations,
                                                        self.threshold)
-        # return the beats if no activations given / remain after thresholding
+        # return no beats if no activations given / remain after thresholding
         if not activations.any():
             return beats
         # get the best state path by calling the viterbi algorithm
         path, _ = self.hmm.viterbi(activations)
+        # also return no beats if no path was found
+        if not path.any():
+            return beats
         # correct the beat positions if needed
         if self.correct:
             # for each detection determine the "beat range", i.e. states where

--- a/tests/test_features_beats.py
+++ b/tests/test_features_beats.py
@@ -154,3 +154,8 @@ class TestDBNBeatTrackingProcessorClass(unittest.TestCase):
         beats = [processor.process_forward(np.atleast_1d(act), reset=False)
                  for act in sample_lstm_act]
         self.assertTrue(np.allclose(np.nonzero(beats), [3, 79, 149, 216, 252]))
+
+    def test_empty_path(self):
+        # beat activation which leads to an empty path
+        act = np.array([0, 1, 0, 1, 0, 1])
+        self.assertTrue(np.allclose(self.processor(act), []))


### PR DESCRIPTION
## Changes proposed in this pull request

In rare cases no Viterbi path can be found for a given beat activation. Return no beats in this case.