### PR TITLE
add padding option to signal_frame()

### DIFF
--- a/madmom/audio/signal.py
+++ b/madmom/audio/signal.py
@@ -840,7 +840,7 @@ class SignalProcessor(Processor):
 
 
 # functions for splitting a signal into frames
-def signal_frame(signal, index, frame_size, hop_size, origin=0):
+def signal_frame(signal, index, frame_size, hop_size, origin=0, pad=0):
     """
     This function returns frame at `index` of the `signal`.
 
@@ -856,6 +856,10 @@ def signal_frame(signal, index, frame_size, hop_size, origin=0):
         Hop size in samples between adjacent frames.
     origin : int
         Location of the window center relative to the signal position.
+    pad : int, float or str, optional
+        Pad parts of the frame not covered by the signal with this value.
+        The literal 'repeat' can be used to indicate that the first/last value
+        should be repeated.
 
     Returns
     -------
@@ -898,37 +902,47 @@ def signal_frame(signal, index, frame_size, hop_size, origin=0):
     start = ref_sample - frame_size // 2 - int(origin)
     stop = start + frame_size
     # return the requested portion of the signal
+    # Note: use NumPy's advanced indexing (i.e. trailing comma) in order to
+    #       avoid a memory leak (issue #321). This returns a copy of the data,
+    #       however, returning a simple copy of the relevant portion of the
+    #       signal also leaks memory
+    # Update: removing this hack again, since it seems that it is not needed
+    #         any more with recent NumPy versions
+    if start >= 0 and stop <= num_samples:
+        # normal read operation, return appropriate section
+        return signal[start:stop]
+
+    # part of the frame falls outside the signal, padding needed
     # Note: np.pad(signal[from: to], (pad_left, pad_right), mode='constant')
     #       always returns a ndarray, not the subclass (and is slower);
     #       usually np.zeros_like(signal[:frame_size]) is exactly what we want
     #       (i.e. zeros of frame_size length and the same type/class as the
     #       signal and not just the dtype), but since we have no guarantee that
     #       the signal is that long, we have to use the np.repeat workaround
-    # Note: use NumPy's advanced indexing (i.e. trailing comma) in order to
-    #       avoid a memory leak (issue #321). This returns a copy of the data,
-    #       however, returning a simple copy of the relevant portion of the
-    #       signal also leaks memory
-    if (stop < 0) or (start > num_samples):
-        # window falls completely outside the actual signal, return just zeros
-        frame = np.repeat(signal[:1] * 0, frame_size, axis=0)
-        return frame
-    elif (start < 0) and (stop > num_samples):
-        # window surrounds the actual signal, position signal accordingly
-        frame = np.repeat(signal[:1] * 0, frame_size, axis=0)
-        frame[-start:num_samples - start] = signal
-        return frame
-    elif start < 0:
-        # window crosses left edge of actual signal, pad zeros from left
-        frame = np.repeat(signal[:1] * 0, frame_size, axis=0)
-        frame[-start:] = signal[:stop, ]
-        return frame
-    elif stop > num_samples:
-        # window crosses right edge of actual signal, pad zeros from right
-        frame = np.repeat(signal[:1] * 0, frame_size, axis=0)
-        frame[:num_samples - start] = signal[start:, ]
-        return frame
-    # normal read operation
-    return signal[start:stop, ]
+    frame = np.repeat(signal[:1], frame_size, axis=0)
+
+    # determine how many samples need to be padded from left/right
+    left, right = 0, 0
+    if start < 0:
+        left = min(stop, 0) - start
+        # repeat beginning of signal
+        frame[:left] = np.repeat(signal[:1], left, axis=0)
+        if pad != 'repeat':
+            frame[:left] = pad
+        start = 0
+    if stop > num_samples:
+        right = stop - max(start, num_samples)
+        # repeat end of signal
+        frame[-right:] = np.repeat(signal[-1:], right, axis=0)
+        if pad != 'repeat':
+            frame[-right:] = pad
+        stop = num_samples
+
+    # position signal inside frame
+    frame[left:frame_size - right] = signal[min(start, num_samples):
+                                            max(stop, 0)]
+    # return the frame
+    return frame
 
 
 FRAME_SIZE = 2048

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -987,6 +987,49 @@ class TestSignalFrameFunction(unittest.TestCase):
         result = signal_frame(np.arange(10), 0, 5, 2, -2.5)
         self.assertTrue(np.allclose(result, [0, 1, 2, 3, 4]))
 
+    def test_pad(self):
+        # 1D signal
+        x = np.arange(10, 20)
+        # pad with a fixed value
+        result = signal_frame(x, 0, frame_size=4, hop_size=2, pad=-1)
+        self.assertTrue(np.allclose(result, [-1, -1, 10, 11]))
+        result = signal_frame(x, 5, frame_size=4, hop_size=2, pad=-1)
+        self.assertTrue(np.allclose(result, [18, 19, -1, -1]))
+        # repeat first value
+        result = signal_frame(x, 0, frame_size=4, hop_size=2, pad='repeat')
+        self.assertTrue(np.allclose(result, [10, 10, 10, 11]))
+        result = signal_frame(x, -10, frame_size=4, hop_size=2, pad='repeat')
+        self.assertTrue(np.allclose(result, [10, 10, 10, 10]))
+        # repeat last value
+        result = signal_frame(x, 0, frame_size=4, hop_size=2, pad='repeat')
+        self.assertTrue(np.allclose(result, [10, 10, 10, 11]))
+        result = signal_frame(x, 20, frame_size=3, hop_size=3, pad='repeat')
+        self.assertTrue(np.allclose(result, [19, 19, 19]))
+
+        # 2D signal
+        x = np.arange(10, 30).reshape((10, 2))
+        # pad with a fixed value
+        result = signal_frame(x, 0, frame_size=4, hop_size=2, pad=-1)
+        self.assertTrue(
+            np.allclose(result, [[-1, -1], [-1, -1], [10, 11], [12, 13]]))
+        result = signal_frame(x, 0, frame_size=4, hop_size=2, pad=[-1, -2])
+        self.assertTrue(
+            np.allclose(result, [[-1, -2], [-1, -2], [10, 11], [12, 13]]))
+        # pad by repeating first/last frame
+        result = signal_frame(x, 0, frame_size=4, hop_size=2, pad='repeat')
+        self.assertTrue(
+            np.allclose(result, [[10, 11], [10, 11], [10, 11], [12, 13]]))
+        result = signal_frame(x, 5, frame_size=4, hop_size=2, pad='repeat')
+        self.assertTrue(
+            np.allclose(result, [[26, 27], [28, 29], [28, 29], [28, 29]]))
+        # requested frame out of signal
+        result = signal_frame(x, -2, frame_size=4, hop_size=2, pad='repeat')
+        self.assertTrue(
+            np.allclose(result, [[10, 11], [10, 11], [10, 11], [10, 11]]))
+        result = signal_frame(x, 7, frame_size=4, hop_size=2, pad='repeat')
+        self.assertTrue(
+            np.allclose(result, [[28, 29], [28, 29], [28, 29], [28, 29]]))
+
 
 # framing classes
 class TestFramedSignalClass(unittest.TestCase):


### PR DESCRIPTION
## Changes proposed in this pull request

This PR adds an option to `signal_frame()` to specify the value which should be used when padding of the signal is required.
Either the value is given directly or the literal 'repeat' can be used to repeat the first/last sample of the signal.