### PR TITLE
add option to select a specific input device for live audio input

### DIFF
--- a/madmom/audio/signal.py
+++ b/madmom/audio/signal.py
@@ -1396,6 +1396,8 @@ class Stream(object):
     fps : float, optional
         Use given frames per second; if set, this computes and overwrites the
         given `hop_size` value (the resulting `hop_size` must be an integer).
+    stream_input_device : int, optional
+        PyAudio device index of the desired input device.
     queue_size : int
         Size of the FIFO (first in first out) queue. If the queue is full and
         new audio samples arrive, the oldest item in the queue will be dropped.
@@ -1409,7 +1411,7 @@ class Stream(object):
 
     def __init__(self, sample_rate=SAMPLE_RATE, num_channels=NUM_CHANNELS,
                  dtype=np.float32, frame_size=FRAME_SIZE, hop_size=HOP_SIZE,
-                 fps=FPS, **kwargs):
+                 fps=FPS, stream_input_device=None, **kwargs):
         # import PyAudio here and not at the module level
         import pyaudio
         # set attributes
@@ -1425,6 +1427,7 @@ class Stream(object):
             raise ValueError(
                 'only integer `hop_size` supported, not %s' % hop_size)
         self.hop_size = int(hop_size)
+        self.stream_input_device = stream_input_device
         # init PyAudio
         self.pa = pyaudio.PyAudio()
         # init a stream to read audio samples from
@@ -1432,6 +1435,7 @@ class Stream(object):
                                    channels=self.num_channels,
                                    format=pyaudio.paFloat32, input=True,
                                    frames_per_buffer=self.hop_size,
+                                   input_device_index=self.stream_input_device,
                                    start=True)
         # create a buffer
         self.buffer = BufferProcessor(self.frame_size)

--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -999,6 +999,10 @@ def io_arguments(parser, output_suffix='.txt', pickle=True, online=False):
                         default=output, help='output file [default: STDOUT]')
         sp.add_argument('-j', dest='num_threads', type=int, default=1,
                         help='number of threads [default=%(default)s]')
+        sp.add_argument('--device', dest='stream_input_device', type=int,
+                        default=None, help='PyAudio device index of the '
+                                           'desired input device. '
+                                           '[default=%(default)s]')
         # set arguments for loading processors
         sp.set_defaults(online=True)      # use online settings/parameters
         sp.set_defaults(num_frames=1)     # process everything frame-by-frame


### PR DESCRIPTION
Patch supplied by Ian Charnas
(https://groups.google.com/d/msg/madmom-users/yYtp6Y43yWQ/vCgoC2uaBwAJ)

## Changes proposed in this pull request

- `stream_input_device` added to `Stream` class to be able to select an input stream device,
- `--device` command line option added to be visible in `bin`-scripts