### PR TITLE
fix failing find_longest_continuous_segment() test 

### DIFF
--- a/tests/test_evaluation_beats.py
+++ b/tests/test_evaluation_beats.py
@@ -173,9 +173,9 @@ class TestFindLongestContinuousSegmentFunction(unittest.TestCase):
 
     def test_errors(self):
         # events must be correct type
-        with self.assertRaises(IndexError):
+        with self.assertRaises((IndexError, ValueError)):
             find_longest_continuous_segment(None)
-        with self.assertRaises(IndexError):
+        with self.assertRaises((IndexError, ValueError)):
             find_longest_continuous_segment(1)
 
     def test_values(self):


### PR DESCRIPTION
numpy 1.17 raises ValueError instead of IndexError