### PR TITLE
Select stream input device

### DIFF
--- a/madmom/audio/signal.py
+++ b/madmom/audio/signal.py
@@ -1396,6 +1396,8 @@ class Stream(object):
     fps : float, optional
         Use given frames per second; if set, this computes and overwrites the
         given `hop_size` value (the resulting `hop_size` must be an integer).
+    stream_input_device : int, optional
+        PyAudio device index of the desired input device.
     queue_size : int
         Size of the FIFO (first in first out) queue. If the queue is full and
         new audio samples arrive, the oldest item in the queue will be dropped.
@@ -1409,7 +1411,7 @@ class Stream(object):
 
     def __init__(self, sample_rate=SAMPLE_RATE, num_channels=NUM_CHANNELS,
                  dtype=np.float32, frame_size=FRAME_SIZE, hop_size=HOP_SIZE,
-                 fps=FPS, **kwargs):
+                 fps=FPS, stream_input_device=None, **kwargs):
         # import PyAudio here and not at the module level
         import pyaudio
         # set attributes
@@ -1425,6 +1427,7 @@ class Stream(object):
             raise ValueError(
                 'only integer `hop_size` supported, not %s' % hop_size)
         self.hop_size = int(hop_size)
+        self.stream_input_device = stream_input_device
         # init PyAudio
         self.pa = pyaudio.PyAudio()
         # init a stream to read audio samples from
@@ -1432,6 +1435,7 @@ class Stream(object):
                                    channels=self.num_channels,
                                    format=pyaudio.paFloat32, input=True,
                                    frames_per_buffer=self.hop_size,
+                                   input_device_index=self.stream_input_device,
                                    start=True)
         # create a buffer
         self.buffer = BufferProcessor(self.frame_size)

--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -999,6 +999,10 @@ def io_arguments(parser, output_suffix='.txt', pickle=True, online=False):
                         default=output, help='output file [default: STDOUT]')
         sp.add_argument('-j', dest='num_threads', type=int, default=1,
                         help='number of threads [default=%(default)s]')
+        sp.add_argument('--device', dest='stream_input_device', type=int,
+                        default=None, help='PyAudio device index of the '
+                                           'desired input device. '
+                                           '[default=%(default)s]')
         # set arguments for loading processors
         sp.set_defaults(online=True)      # use online settings/parameters
         sp.set_defaults(num_frames=1)     # process everything frame-by-frame

--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -863,6 +863,15 @@ def process_online(processor, infile, outfile, **kwargs):
     # set default values
     kwargs['sample_rate'] = kwargs.get('sample_rate', 44100)
     kwargs['num_channels'] = kwargs.get('num_channels', 1)
+    # list all available PyAudio devices and exit afterwards
+    if kwargs['list_stream_input_device']:
+        import pyaudio
+        pa = pyaudio.PyAudio()
+        for i in range(pa.get_device_count()):
+            info = pa.get_device_info_by_index(i)
+            print('%d: %s' % (info['index'], info['name']))
+        exit(0)
+
     # if no input file is given, create a Stream with the given arguments
     if infile is None:
         # open a stream and start if not running already
@@ -1001,8 +1010,13 @@ def io_arguments(parser, output_suffix='.txt', pickle=True, online=False):
                         help='number of threads [default=%(default)s]')
         sp.add_argument('--device', dest='stream_input_device', type=int,
                         default=None, help='PyAudio device index of the '
-                                           'desired input device. '
+                                           'desired input device '
                                            '[default=%(default)s]')
+        sp.add_argument('--list', dest='list_stream_input_device',
+                        action='store_true', default=False,
+                        help='show a list of available PyAudio devices; index '
+                             'can be used as STREAM_INPUT_DEVICE for the '
+                             '--device argument')
         # set arguments for loading processors
         sp.set_defaults(online=True)      # use online settings/parameters
         sp.set_defaults(num_frames=1)     # process everything frame-by-frame


### PR DESCRIPTION
## Changes proposed in this pull request

- `stream_input_device` added to `Stream` class to be able to select an input stream device,
- `--device` command line option added to be visible in `bin`-scripts
- `--list` command line option shows a list of available PyAudio devices

Original patch provided by Ian Charnas (https://groups.google.com/d/msg/madmom-users/yYtp6Y43yWQ/vCgoC2uaBwAJ)
