### PR TITLE
Add PEP518-style build system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "cython>=0.25",
+    "numpy>=1.13.4;python_version!='3.5'",
+    "numpy>=1.13.4,<=1.15.2;python_version=='3.5'"
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Changes proposed in this pull request

This PR declares `madmom`'s build-time dependencies via a `pyproject.toml` per [PEP 518](https://www.python.org/dev/peps/pep-0518/).

Without this change, the latest version of `madmom` is uninstallable on systems without previously installing `cython` and `numpy` in a separate install command. This makes `madmom` unusable in runtimes like Google Cloud Functions, where all dependencies are declared in a single file and installed at the same time. (for example, [this Stack Overflow issue about `madmom` being uninstallable on Google Cloud Functions](https://stackoverflow.com/questions/58233081/python-google-cloud-function-deployment-failure-madmom-pip-package))

Without this change, installation fails:
```
$ pip freeze

$ pip install madmom
Collecting madmom
  Downloading https://files.pythonhosted.org/packages/c7/a3/9f3de3e8068a3606331134d96b84c8db4f7624d6715be8ab3c1f56e6731d/madmom-0.16.1.tar.gz (20.0MB)
     |████████████████████████████████| 20.0MB 8.7MB/s
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-ounholra/madmom/setup.py'"'"'; __file__='"'"'/tmp/pip-install-ounholra/madmom/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base pip-egg-info
         cwd: /tmp/pip-install-ounholra/madmom/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-ounholra/madmom/setup.py", line 12, in <module>
        from Cython.Build import cythonize, build_ext
    ModuleNotFoundError: No module named 'Cython'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

With this change, it installs correctly:
```
$ pip freeze

$ pip install git+https://github.com/di/madmom.git@pep-518
Collecting git+https://github.com/di/madmom.git@pep-518
  Cloning https://github.com/di/madmom.git (to revision pep-518) to /tmp/pip-req-build-oxvdemza
  Running command git clone -q https://github.com/di/madmom.git /tmp/pip-req-build-oxvdemza
  Running command git checkout -b pep-518 --track origin/pep-518
  Switched to a new branch 'pep-518'
  Branch 'pep-518' set up to track remote branch 'pep-518' from 'origin'.
  Running command git submodule update --init --recursive -q
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
    Preparing wheel metadata ... done
Collecting cython>=0.25 (from madmom==0.17.dev0)
  Using cached https://files.pythonhosted.org/packages/f1/d3/03a01bcf424eb86d3e9d818e2082ced2d512001af89183fca6f550c32bc2/Cython-0.29.13-cp37-cp37m-manylinux1_x86_64.whl
Collecting numpy>=1.13.4 (from madmom==0.17.dev0)
  Using cached https://files.pythonhosted.org/packages/ba/e0/46e2f0540370f2661b044647fa447fef2ecbcc8f7cdb4329ca2feb03fb23/numpy-1.17.2-cp37-cp37m-manylinux1_x86_64.whl
Collecting mido>=1.2.8 (from madmom==0.17.dev0)
  Downloading https://files.pythonhosted.org/packages/20/0a/81beb587b1ae832ea6a1901dc7c6faa380e8dd154e0a862f0a9f3d2afab9/mido-1.2.9-py2.py3-none-any.whl (52kB)
     |████████████████████████████████| 61kB 667kB/s
Collecting scipy>=0.16 (from madmom==0.17.dev0)
  Downloading https://files.pythonhosted.org/packages/94/7f/b535ec711cbcc3246abea4385d17e1b325d4c3404dd86f15fc4f3dba1dbb/scipy-1.3.1-cp37-cp37m-manylinux1_x86_64.whl (25.2MB)
     |████████████████████████████████| 25.2MB 608kB/s
Building wheels for collected packages: madmom
  Building wheel for madmom (PEP 517) ... done
  Created wheel for madmom: filename=madmom-0.17.dev0-cp37-cp37m-linux_x86_64.whl size=25718483 sha256=343d7fd26d7ef9ad631e1b0089e9c568932cddfa79c56a21737aafb979949b5b
  Stored in directory: /tmp/pip-ephem-wheel-cache-pvi0c1th/wheels/47/70/3d/8eda916cd2e91991b5f4ad547c1faa569e65e9df8ff14069ba
Successfully built madmom
Installing collected packages: cython, numpy, mido, scipy, madmom
Successfully installed cython-0.29.13 madmom-0.17.dev0 mido-1.2.9 numpy-1.17.2 scipy-1.3.1

$ pip freeze
Cython==0.29.13
madmom==0.17.dev0
mido==1.2.9
numpy==1.17.2
scipy==1.3.1
```