### PR TITLE
fix AttributeError: 'Signal' object has no attribute 'sample_rate'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,19 @@ language: python
 matrix:
   include:
     - python: 2.7
-      dist: trusty
+      dist: xenial
       sudo: required
     - python: 3.5
-      dist: trusty
+      dist: xenial
       sudo: required
     - python: 3.6
-      dist: trusty
+      dist: xenial
       sudo: required
     - python: 3.7
       dist: xenial
       sudo: required
 before_install:
   # get a working ffmpeg
-  - sudo add-apt-repository --yes ppa:jonathonf/ffmpeg-3
   - sudo apt-get update -qq
   - sudo apt-get install -qq ffmpeg
   - sudo apt-get install -qq libfftw3-dev

--- a/madmom/audio/signal.py
+++ b/madmom/audio/signal.py
@@ -638,6 +638,22 @@ class Signal(np.ndarray):
         self.start = getattr(obj, 'start', None)
         self.stop = getattr(obj, 'stop', None)
 
+    def __reduce__(self):
+        # Get the parent's __reduce__ tuple
+        state = super(Signal, self).__reduce__()
+        # Create our own tuple to pass to __setstate__, but append the
+        # __dict__ rather than individual members
+        new_state = state[2] + (self.__dict__,)
+        # Return a tuple that replaces the parent's __setstate__ tuple with
+        # our own
+        return state[0], state[1], new_state
+
+    def __setstate__(self, state):
+        # Update the internal dict from state
+        self.__dict__.update(state[-1])
+        # Call the parent's __setstate__ with the other tuple elements
+        super(Signal, self).__setstate__(state[:-1])
+
     @property
     def num_samples(self):
         """Number of samples."""

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -894,6 +894,13 @@ class TestSignalProcessorClass(unittest.TestCase):
         self.assertEqual(self.processor.norm, processor.norm)
         self.assertEqual(self.processor.gain, processor.gain)
 
+    @unittest.skipIf(sys.version_info < (3, 2), 'assertWarns needs Python 3.2')
+    def test_multiprocessing(self):
+        from concurrent.futures import ProcessPoolExecutor
+        sig = Signal(sample_file)
+        pool = ProcessPoolExecutor(max_workers=2)
+        pool.submit(self.processor, sig).result()
+
 
 # framing functions
 class TestSignalFrameFunction(unittest.TestCase):


### PR DESCRIPTION
## Changes proposed in this pull request

Save `sample_rate` attribute of `Signal` to make processors involving `Signal` pickleable.

This pull request fixes #454 
