### PR TITLE
fixed typo in description within spectrogram.py

### DIFF
--- a/madmom/audio/spectrogram.py
+++ b/madmom/audio/spectrogram.py
@@ -1112,7 +1112,7 @@ class SpectrogramDifferenceProcessor(Processor):
         args.update(kwargs)
         # calculate the number of diff frames
         if self.diff_frames is None:
-            # Note: use diff_ration from args, not self.diff_ratio
+            # Note: use diff_ratio from args, not self.diff_ratio
             self.diff_frames = _diff_frames(
                 args['diff_ratio'], frame_size=data.stft.frames.frame_size,
                 hop_size=data.stft.frames.hop_size, window=data.stft.window)


### PR DESCRIPTION
## Changes proposed in this pull request

Please provide a detailed description of the changes proposed in this pull
request. This can either be a textual description or a simple list.

- fixed typo in the description within spectrogram.py where diff_ratio is miss spelled as diff_ration

