### PR TITLE
Pin numpy version at build to handle Numpy's API change in v1.20

### DIFF
--- a/madmom/processors.py
+++ b/madmom/processors.py
@@ -20,7 +20,7 @@ import itertools as it
 import multiprocessing as mp
 import os
 import sys
-from collections import MutableSequence
+from collections.abc import MutableSequence
 
 import madmom
 import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
     "setuptools",
     "wheel",
     "cython>=0.25",
-    "numpy>=1.13.4;python_version!='3.5'",
-    "numpy>=1.13.4,<=1.15.2;python_version=='3.5'"
+    "oldest-supported-numpy"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Changes proposed in this pull request

The [C-API change in Numpy v1.20](https://numpy.org/doc/stable/release/1.20.0-notes.html#c-api-changes) has the potential to cause incompatibility issues, as seen in https://github.com/CPJKU/madmom/issues/469#issuecomment-802535058.

This happens when a user hasn't upgraded yet to Numpy 1.20 (or can't upgrade, e.g. because of apt-get availability or pinned due to Tensorflow requirements). Because the build requirement in `pyproject.toml` is an unversioned numpy, it will pull in the latest >=1.20 version and build madmom against it, which gives problems when running with the <1.20 version because the latter is not forward compatible.

Numpy's C-API is forward compatible though, so the solution is to pin the build version at a low enough version, it doesn't matter if this version is lower than the version used at runtime. You could do this per Python version, as is currently done in `pyproject.toml`, but there even is a meta-package for this since it's a common problem. Using the meta-package also makes the solution robust against future Python versions, so that's what I did for this PR.

I also snuck in an unrelated warning fix that will become an error in Python 3.10 (due in October).