### PR TITLE
Fix bad log densities

### DIFF
--- a/madmom/features/beats_hmm.py
+++ b/madmom/features/beats_hmm.py
@@ -628,7 +628,7 @@ class RNNDownBeatTrackingObservationModel(ObservationModel):
         log_densities = np.empty((len(observations), 3), dtype=np.float)
         # Note: it's faster to call np.log multiple times instead of once on
         #       the whole 2d array
-        log_densities[:, 0] = np.log((1. - np.sum(observations, axis=1)) /
+        log_densities[:, 0] = np.log((1. - observations[:, 0]) /
                                      (self.observation_lambda - 1))
         log_densities[:, 1] = np.log(observations[:, 0])
         log_densities[:, 2] = np.log(observations[:, 1])

--- a/madmom/features/downbeats.py
+++ b/madmom/features/downbeats.py
@@ -290,7 +290,7 @@ class DBNDownBeatTrackingProcessor(Processor):
         positions = st.state_positions[path]
         # corresponding beats (add 1 for natural counting)
         beat_numbers = positions.astype(int) + 1
-        if self.correct:
+        if len(path) > 0 and self.correct:
             beats = np.empty(0, dtype=np.int)
             # for each detection determine the "beat range", i.e. states where
             # the pointers of the observation model are >= 1


### PR DESCRIPTION
## Changes proposed in this pull request

Please provide a detailed description of the changes proposed in this pull
request. This can either be a textual description or a simple list.

In line 629 of `beats_hmm.py`, the sum of the beats and downbeats observation is used to calculate the log density for non-beat states. These, however, are not guaranteed to define a joint probability density function, which causes the sum to be potentially greater than 1 and the logarithm of a negative number to be used. Since beats are also downbeats, we can simply take the beat observation instead.

If the viterbi algorithm fails to decode a valid path (e.g. as a result of the above error), it returns an empty array, which is indexed in line 305 of `downbeats.py`, causing an IndexError. To avoid this, we can simply check if the array is empty in line 297.

This pull request fixes #488 #489 .
