### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -371,7 +371,7 @@ Acknowledgements
 ================
 
 Supported by the European Commission through the `GiantSteps project
-<http://www.giantsteps-project.eu>`_ (FP7 grant agreement no. 610591) and the
+<http://www.giantsteps-project.upf.edu>`_ (FP7 grant agreement no. 610591) and the
 `Phenicx project <http://phenicx.upf.edu>`_ (FP7 grant agreement no. 601166)
 as well as the `Austrian Science Fund (FWF) <https://www.fwf.ac.at>`_ project
 Z159.


### PR DESCRIPTION
fix external link rot

## Changes proposed in this pull request
- link for the giant-steps project will point to an appropriate landing page. (was sending me to something totally different, something about online casino, but I can't read the language.)

This pull request fixes #.
- I apoligize, there is no related Issue, and I did not try to create an Issue. I searched, and I saw a few related to 'documentation' but not this, not any Issues about link rot.