### PR TITLE
Update introduction.rst

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -4,7 +4,7 @@ Introduction
 Madmom is an audio signal processing library written in Python with a strong
 focus on music information retrieval (MIR) tasks. The project is on `GitHub`_.
 
-It's main features / design goals are:
+Its main features / design goals are:
 
 * ease of use,
 * rapid prototyping of signal processing workflows,


### PR DESCRIPTION
It's -> Its

## Changes proposed in this pull request

Fixes a grammatical error: "It's" means "It is", but here we're using a possessive pronoun.