### PR TITLE
Fix setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,8 +95,12 @@ Package Index) <https://pypi.python.org/pypi>`_::
 
     pip install madmom
 
-This includes the latest code and trained models and will install all
-dependencies automatically.
+This includes the latest stable release and will install all dependencies
+automatically.
+
+Alternatively, if you prefer the latest code that might be unstable::
+
+    pip install git+https://github.com/CPJKU/madmom
 
 You might need higher privileges (use su or sudo) to install the package, model
 files and scripts globally. Alternatively you can install the package locally

--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,11 @@ scripts = glob.glob('bin/*')
 package_data = [
     'models/LICENSE',
     'models/README.rst',
-    'models/beats/201[56]/*',
+    'models/beats/*/*',
     'models/chords/*/*',
     'models/chroma/*/*',
     'models/downbeats/*/*',
-    'models/key/2018/*',
+    'models/key/*/*',
     'models/notes/*/*',
     'models/onsets/*/*',
     'models/patterns/*/*',


### PR DESCRIPTION
## Changes proposed in this pull request

Fixes a bug in `setup.py` that causes `models/beats/2019` to be accidentally excluded.