### PR TITLE
Fix broken tests by including required assets in package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ scripts = glob.glob('bin/*')
 package_data = [
     'models/LICENSE',
     'models/README.rst',
-    'models/beats/201[56]/*',
+    'models/beats/*/*',
     'models/chords/*/*',
     'models/chroma/*/*',
     'models/downbeats/*/*',

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -44,17 +44,24 @@ sys.dont_write_bytecode = True
 
 
 def run_program(program):
-    # import module, capture stdout
+    # import module, capture stdout and stderr
     test = imp.load_source('test', program[0])
     sys.argv = program
-    backup = sys.stdout
+    stdout = sys.stdout
+    stderr = sys.stderr
+    # redirect stdout and stderr
     sys.stdout = StringIO()
+    sys.stderr = StringIO()
     # run the program
     data = test.main()
-    # close stdout, restore environment
-    sys.stdout.getvalue()
+    # display stdout and stderr
+    print(sys.stdout.getvalue(), file=stdout)
+    print(sys.stderr.getvalue(), file=stderr)
+    # close and restore environment
     sys.stdout.close()
-    sys.stdout = backup
+    sys.stderr.close()
+    sys.stdout = stdout
+    sys.stderr = stderr
     return data
 
 


### PR DESCRIPTION
Working on packaging madmom in nixpkgs ([WIP here](https://github.com/carlthome/mirpkgs/pull/6)) and noticed that specific tests failed when testing the installed (non-editable) package by:

### MCVE
```sh
git clone https://github.com/CPJKU/madmom.git
cd madmom

git submodule init
git submodule update

python -m venv .venv
source .venv/bin/activate

pip install .
pip install pytest

rm -r madmom

pytest
```

### Output
```sh
====================================================== short test summary info ======================================================
FAILED tests/test_bin.py::TestTCNBeatTrackerProgram::test_binary - IndexError: list index out of range
FAILED tests/test_bin.py::TestTCNBeatTrackerProgram::test_run - IndexError: list index out of range
FAILED tests/test_bin.py::TestTCNTempoDetectorProgram::test_binary - IndexError: list index out of range
FAILED tests/test_bin.py::TestTCNTempoDetectorProgram::test_run - IndexError: list index out of range
FAILED tests/test_features_beats.py::TestTCNBeatProcessorClass::test_process_tcn - IndexError: list index out of range
====================================== 5 failed, 806 passed, 188 warnings in 60.53s (0:01:00) =======================================
```

Turns out these tests depend on static assets (2019 models) that are currently not included in package_data. This PR fixes that such that the installed package passes its tests.