### PR TITLE
replace deprecated numpy.math use with libc.math

### DIFF
--- a/madmom/features/beats_crf.pyx
+++ b/madmom/features/beats_crf.pyx
@@ -23,7 +23,7 @@ from scipy.ndimage import correlate1d
 cimport numpy as np
 cimport cython
 
-from numpy.math cimport INFINITY
+from libc.math cimport INFINITY
 
 
 def initial_distribution(num_states, interval):

--- a/madmom/ml/hmm.pyx
+++ b/madmom/ml/hmm.pyx
@@ -23,7 +23,7 @@ cimport numpy as np
 cimport cython
 np.import_array()
 
-from numpy.math cimport INFINITY
+from libc.math cimport INFINITY
 
 
 ctypedef np.uint32_t uint32_t


### PR DESCRIPTION
## Changes proposed in this pull request

Use libc.math to import INFINITY rather than deprecated numpy.math

https://github.com/cython/cython/blob/e2e63cb22b2fcc4f5a3780707b0b24fb6be0ffe1/Cython/Includes/numpy/math.pxd#L21-L23

This pull request fixes https://github.com/CPJKU/madmom/issues/547.

Note: even though `numpy.math` was only deprecated and should still work, builds now fail due to numpy missing from Cython 3.1 wheels https://github.com/cython/cython/issues/6859. Presumably that will be corrected, but we should update to use `libc.math` going forward, and should consider placing an upper bound on dependencies to be resilient to similar issues in the future.