### PR TITLE
fixed NumPy INFINITY import

### DIFF
--- a/madmom/features/beats_crf.pyx
+++ b/madmom/features/beats_crf.pyx
@@ -195,7 +195,7 @@ def viterbi(float [::1] pi, float[::1] transition, float[::1] norm_factor,
     # iterate over all beats; the 1st beat is given by prior
     for k in range(num_x - 1):
         # reset all current viterbi variables
-        v_c[:] = -np.NPY_INFINITY
+        v_c[:] = -np.inf
 
         # find the best transition for each state i
         for i in range(num_st):
@@ -221,7 +221,7 @@ def viterbi(float [::1] pi, float[::1] transition, float[::1] norm_factor,
         v_p, v_c = v_c, v_p
 
     # add the final best state to the path
-    path_prob = -np.NPY_INFINITY
+    path_prob = -np.inf
     for i in range(num_st):
         # subtract the norm factor because they shouldn't have been added
         # for the last random variable

--- a/madmom/features/beats_crf.pyx
+++ b/madmom/features/beats_crf.pyx
@@ -23,8 +23,6 @@ from scipy.ndimage import correlate1d
 cimport numpy as np
 cimport cython
 
-from numpy.math cimport INFINITY
-
 
 def initial_distribution(num_states, interval):
     """
@@ -197,7 +195,7 @@ def viterbi(float [::1] pi, float[::1] transition, float[::1] norm_factor,
     # iterate over all beats; the 1st beat is given by prior
     for k in range(num_x - 1):
         # reset all current viterbi variables
-        v_c[:] = -INFINITY
+        v_c[:] = -np.NPY_INFINITY
 
         # find the best transition for each state i
         for i in range(num_st):
@@ -223,7 +221,7 @@ def viterbi(float [::1] pi, float[::1] transition, float[::1] norm_factor,
         v_p, v_c = v_c, v_p
 
     # add the final best state to the path
-    path_prob = -INFINITY
+    path_prob = -np.NPY_INFINITY
     for i in range(num_st):
         # subtract the norm factor because they shouldn't have been added
         # for the last random variable

--- a/madmom/ml/hmm.pyx
+++ b/madmom/ml/hmm.pyx
@@ -23,8 +23,6 @@ cimport numpy as np
 cimport cython
 np.import_array()
 
-from numpy.math cimport INFINITY
-
 
 ctypedef np.uint32_t uint32_t
 
@@ -528,7 +526,7 @@ class HiddenMarkovModel(object):
             # search for the best transition
             for state in range(num_states):
                 # reset the current viterbi variable
-                current_viterbi[state] = -INFINITY
+                current_viterbi[state] = -np.NPY_INFINITY
                 # get the observation model probability density value
                 # the om_pointers array holds pointers to the correct
                 # observation probability density value for the actual state

--- a/madmom/ml/hmm.pyx
+++ b/madmom/ml/hmm.pyx
@@ -526,7 +526,7 @@ class HiddenMarkovModel(object):
             # search for the best transition
             for state in range(num_states):
                 # reset the current viterbi variable
-                current_viterbi[state] = -np.NPY_INFINITY
+                current_viterbi[state] = -np.inf
                 # get the observation model probability density value
                 # the om_pointers array holds pointers to the correct
                 # observation probability density value for the actual state


### PR DESCRIPTION
## Changes proposed in this pull request

Currently installation fails due to 'numpy/math/INFINITY.pxd' not found.  This is because the numpy.math module is a deprecated alias for Python's standard math module.  I've updated the usage to np.NPY_INFINITY, which resolves the problem.  

This pull request fixes #550.