### PR TITLE
Add github codespace support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+	"name": "madmom",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.13",
+	"features": {},
+	"postCreateCommand": "pip install -e .",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"hbenl.vscode-test-explorer",
+				"ms-python.python"
+			]
+		}
+	}
+}


### PR DESCRIPTION
GitHub codespace is an online Linux environment with a vscode web UI. It is useful for developers who don't have a Linux device but want to test and debug their code on Linux.

## Changes proposed in this pull request

Added devcontainer.json to add GitHub codespace support
